### PR TITLE
v2.1.2 - Issue #64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ release notes.
 The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.2] - 2026-06-20
+
+### Fixed
+
+- **WebRTC camera feeds no longer fail silently.** PrintGuard reads cameras with FFmpeg,
+  which cannot ingest WebRTC (WHEP/WHIP) streams. A camera that only offered WebRTC — most
+  often a Klipper/Crowsnest setup on **camera-streamer**, the Crowsnest V5 default — was
+  registered but produced no frames, with nothing to say why. Such streams are now detected
+  up front: adding one by hand is rejected with a clear message pointing at the MJPEG
+  (`…?action=stream`) or RTSP URL to use instead, and a printer that exposes only a WebRTC
+  webcam raises a visible warning rather than quietly skipping it.
+- **Klipper webcams on camera-streamer fix.** When Moonraker advertises a webcam as
+  WebRTC, PrintGuard automatically attaches to the same feed's MJPEG endpoint (derived from
+  the webcam's snapshot URL) instead of the unreadable WebRTC one, so no manual reconfiguration
+  is needed. Webcams already served as MJPEG/HLS are unaffected.
+- **Klipper webcam URLs resolve to the right port.** A webcam advertised by a relative path
+  (e.g. `/webcam/?action=stream`) is now fetched from the printer's web port, where the stream
+  is actually served, rather than Moonraker's API port (7125) — which carries no webcam routes
+  and silently produced no frames when the printer was added with its `…:7125` base URL.
+
 ## [2.1.1] - 2026-06-19
 
 ### Added

--- a/printguard/engine/cameras.py
+++ b/printguard/engine/cameras.py
@@ -3,6 +3,27 @@
 from __future__ import annotations
 
 from typing import Any
+from urllib.parse import urlsplit
+
+_WEBRTC_SCHEMES = ("webrtc", "whep", "whip")
+_WEBRTC_PATH_SEGMENTS = frozenset({"webrtc", "whep", "whip"})
+
+
+def webrtc_endpoint(url: str) -> bool:
+    """Whether a stream URL is a WebRTC (WHEP/WHIP) endpoint FFmpeg cannot ingest.
+
+    PrintGuard reads cameras with PyAV/FFmpeg, which speaks RTSP/RTMP and HTTP
+    MJPEG/HLS but not WebRTC. A feed is WebRTC when it uses an explicit signalling
+    scheme (``webrtc://``/``whep://``/``whip://``) or, over HTTP, carries a
+    signalling path segment such as ``/webrtc`` — camera-streamer serves its
+    WebRTC stream at ``/webcam/webrtc``. Relative URLs, as Moonraker may report,
+    are recognised too.
+    """
+    parsed = urlsplit(url)
+    if parsed.scheme in _WEBRTC_SCHEMES:
+        return True
+    return any(segment.lower() in _WEBRTC_PATH_SEGMENTS for segment in parsed.path.split("/"))
+
 
 CAMERA_DEFAULTS: dict[str, Any] = {
     "brightness": 1.0,

--- a/printguard/engine/engine.py
+++ b/printguard/engine/engine.py
@@ -15,7 +15,7 @@ from collections import deque
 from typing import Any, Callable
 
 from . import updates, vision
-from .cameras import sanitise_camera
+from .cameras import sanitise_camera, webrtc_endpoint
 from .integrations import INTEGRATIONS, DeviceAction, integrations_meta
 from .monitors import monitor_watching, persisted_monitor, sanitise_monitor
 from .notifiers import NOTIFIERS, notifiers_meta
@@ -32,6 +32,7 @@ REQUEST_TIMEOUT_S = 15.0
 RECENT_EVENTS_MAX = 100
 RECENT_EVENT_TYPES = ("alert", "warning", "device", "error")
 UPDATE_CHECK_INTERVAL_S = 86400.0
+WEBRTC_UNSUPPORTED = "WebRTC streams (WHEP/WHIP) can't be read — use the MJPEG (…?action=stream) or RTSP URL instead."
 
 SETTINGS_DEFAULTS: dict[str, Any] = {"notifiers": {}, "update_check": True}
 
@@ -313,11 +314,14 @@ class Engine:
         self.emit({"event": "discovered", "sources": fresh, "req_id": message.get("req_id")})
 
     async def _cmd_camera_add(self, message: dict[str, Any]) -> None:
+        source = dict(message["source"])
+        if source.get("kind") == "url" and webrtc_endpoint(str(source.get("url") or "")):
+            raise ValueError(WEBRTC_UNSUPPORTED)
         camera_id = uuid.uuid4().hex[:8]
         camera = Camera(
             id=camera_id,
             name=str(message.get("name") or "Camera").strip() or "Camera",
-            source=dict(message["source"]),
+            source=source,
             max_fps=15.0,
         )
         source = await self.platform.open_camera(camera_id, camera.source)
@@ -394,7 +398,11 @@ class Engine:
             camera_id = f"{printer.id}-{descriptor['key']}"
             if self.cameras.get(camera_id):
                 continue
-            camera = Camera(id=camera_id, name=descriptor["name"], source=dict(descriptor["source"]), printer_id=printer.id, max_fps=15.0)
+            source = dict(descriptor["source"])
+            if source.get("kind") == "url" and webrtc_endpoint(str(source.get("url") or "")):
+                self.emit({"event": "warning", "printer_id": printer.id, "message": f"{descriptor['name']}: {WEBRTC_UNSUPPORTED}"})
+                continue
+            camera = Camera(id=camera_id, name=descriptor["name"], source=source, printer_id=printer.id, max_fps=15.0)
             try:
                 source = await self.platform.open_camera(camera_id, camera.source)
             except Exception:

--- a/printguard/engine/integrations/klipper.py
+++ b/printguard/engine/integrations/klipper.py
@@ -7,8 +7,9 @@ Authorization and CORS (trusted_clients, cors_domains): https://moonraker.readth
 from __future__ import annotations
 
 from typing import Any
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlsplit, urlunsplit
 
+from ..cameras import webrtc_endpoint
 from .base import DeviceAction, DeviceState, DeviceStatus, HttpFn, IntegrationAdapter
 
 _STATUS_MAP = {
@@ -75,21 +76,58 @@ class KlipperAdapter(IntegrationAdapter):
     async def cameras(self, http: HttpFn, config: dict[str, Any]) -> list[dict[str, Any]]:
         """Lists Moonraker's registered webcams via /server/webcams/list.
 
-        Each webcam's stream_url may be relative to the Moonraker host and is
-        resolved against it; its stable uid keys the registered camera.
+        Each webcam's stream_url may be relative, resolved against the host's web
+        port (see ``_resolve``); its stable uid keys the registered camera.
+        Webcams whose service advertises only a WebRTC stream — camera-streamer,
+        the Crowsnest V5 default — are redirected to their MJPEG endpoint, which
+        FFmpeg can read, and skipped if no such endpoint can be derived.
         """
         status, body = await http("GET", f"{config['base_url'].rstrip('/')}/server/webcams/list", headers=self._headers(config))
         if status != 200 or not isinstance(body, dict):
             return []
         found: list[dict[str, Any]] = []
         for webcam in (body.get("result") or {}).get("webcams") or []:
-            if not webcam.get("enabled", True) or not webcam.get("stream_url"):
+            if not webcam.get("enabled", True):
+                continue
+            stream = str(webcam.get("stream_url") or "")
+            if "webrtc" in str(webcam.get("service") or "").lower() or webrtc_endpoint(stream):
+                stream = _mjpeg_endpoint(webcam)
+            if not stream or webrtc_endpoint(stream):
                 continue
             found.append(
                 {
                     "key": str(webcam.get("uid") or webcam.get("name") or len(found)),
                     "name": webcam.get("name") or "Webcam",
-                    "source": {"kind": "url", "url": urljoin(config["base_url"], webcam["stream_url"])},
+                    "source": {"kind": "url", "url": _resolve(config["base_url"], stream)},
                 }
             )
         return found
+
+
+def _resolve(base_url: str, stream: str) -> str:
+    """Resolves a webcam URL against the Moonraker host.
+
+    Moonraker reports a relative path (e.g. ``/webcam/?action=stream``) as served
+    on its host's web port, not the API port carried by the base URL — its own
+    documented example resolves ``/webcam/…`` to port 80. The API port (7125)
+    routes no webcam paths, so a relative URL is joined to the bare host; an
+    absolute URL is honoured verbatim.
+    """
+    if urlsplit(stream).scheme:
+        return stream
+    host = urlsplit(base_url)
+    return urljoin(urlunsplit((host.scheme, host.hostname or "", "", "", "")), stream)
+
+
+def _mjpeg_endpoint(webcam: dict[str, Any]) -> str:
+    """Derives camera-streamer's MJPEG endpoint for a WebRTC-advertised webcam.
+
+    camera-streamer serves the same feed as MJPEG alongside WebRTC, at the
+    sibling of its snapshot (``…/?action=snapshot`` → ``…/?action=stream``) or of
+    its WebRTC path (``…/webrtc`` → ``…/stream``). The snapshot is preferred as
+    Moonraker reports it verbatim; an empty string means none could be derived.
+    """
+    snapshot = str(webcam.get("snapshot_url") or "")
+    if snapshot:
+        return snapshot.replace("snapshot", "stream")
+    return str(webcam.get("stream_url") or "").replace("webrtc", "stream")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "printguard"
-version = "2.1.1"
+version = "2.1.2"
 description = "Real-time 3D print failure detection"
 
 license = "GPL-2.0-only"

--- a/tests/test_adapters.py
+++ b/tests/test_adapters.py
@@ -10,6 +10,7 @@ import numpy as np
 import pytest
 
 from printguard.engine import vision
+from printguard.engine.cameras import webrtc_endpoint
 from printguard.engine.integrations import INTEGRATIONS, DeviceAction, DeviceStatus
 from printguard.engine.monitors import monitor_watching, sanitise_monitor
 from printguard.engine.notifiers import NOTIFIERS
@@ -226,12 +227,85 @@ async def test_klipper_lists_enabled_webcams() -> None:
     }
     cams = await INTEGRATIONS["klipper"].cameras(RecordingHttp(body=body), {"base_url": "http://kl:7125"})
     assert cams == [
-        {"key": "u1", "name": "Nozzle", "source": {"kind": "url", "url": "http://kl:7125/webcam/?action=stream"}}
-    ], "only enabled webcams with a stream are exposed, keyed by their stable uid"
+        {"key": "u1", "name": "Nozzle", "source": {"kind": "url", "url": "http://kl/webcam/?action=stream"}}
+    ], "only enabled webcams with a stream are exposed, keyed by uid and resolved to the host's web port not the API port"
+
+
+async def test_klipper_camera_streamer_webrtc_falls_back_to_mjpeg() -> None:
+    body = {
+        "result": {
+            "webcams": [
+                {
+                    "name": "Chamber",
+                    "uid": "u1",
+                    "service": "webrtc-camerastreamer",
+                    "stream_url": "/webcam/webrtc",
+                    "snapshot_url": "/webcam/?action=snapshot",
+                    "enabled": True,
+                }
+            ]
+        }
+    }
+    cams = await INTEGRATIONS["klipper"].cameras(RecordingHttp(body=body), {"base_url": "http://kl:7125"})
+    assert cams == [
+        {"key": "u1", "name": "Chamber", "source": {"kind": "url", "url": "http://kl/webcam/?action=stream"}}
+    ], "a WebRTC-only camera-streamer feed is registered via the MJPEG endpoint derived from its snapshot URL"
+
+
+async def test_klipper_resolves_crowsnest_v5_webcams_to_mjpeg() -> None:
+    """Real /server/webcams/list from a Crowsnest V5 / camera-streamer setup (issue #64)."""
+    body = {"result": {"webcams": [
+        {"name": "mjpeg", "enabled": True, "service": "uv4l-mjpeg",
+         "stream_url": "/webcam/?action=stream", "snapshot_url": "/webcam/?action=snapshot",
+         "uid": "9765408a-3251-40b1-836a-890c4db37aca"},
+        {"name": "rtc", "enabled": True, "service": "webrtc-camerastreamer",
+         "stream_url": "/webcam/webrtc", "snapshot_url": "/webcam/?action=snapshot",
+         "uid": "e61f80ed-5eb9-4838-8579-4d8a38b061da"},
+    ]}}
+    cams = await INTEGRATIONS["klipper"].cameras(RecordingHttp(body=body), {"base_url": "http://printer.local:7125"})
+    assert cams == [
+        {"key": "9765408a-3251-40b1-836a-890c4db37aca", "name": "mjpeg",
+         "source": {"kind": "url", "url": "http://printer.local/webcam/?action=stream"}},
+        {"key": "e61f80ed-5eb9-4838-8579-4d8a38b061da", "name": "rtc",
+         "source": {"kind": "url", "url": "http://printer.local/webcam/?action=stream"}},
+    ], "the WebRTC entry is redirected to MJPEG and both resolve to the host's web port, where camera-streamer actually serves frames"
+
+
+async def test_klipper_webrtc_without_snapshot_derives_mjpeg_from_stream_path() -> None:
+    body = {"result": {"webcams": [
+        {"name": "Cam", "uid": "u1", "service": "webrtc-camerastreamer", "stream_url": "/webcam/webrtc", "enabled": True},
+    ]}}
+    cams = await INTEGRATIONS["klipper"].cameras(RecordingHttp(body=body), {"base_url": "http://kl"})
+    assert cams[0]["source"]["url"] == "http://kl/webcam/stream", "absent a snapshot URL the MJPEG path is derived from the WebRTC path"
+
+
+async def test_klipper_skips_webrtc_with_no_ingestible_endpoint() -> None:
+    body = {"result": {"webcams": [
+        {"name": "WHEP", "uid": "u1", "stream_url": "whep://kl/webcam", "enabled": True},
+    ]}}
+    assert await INTEGRATIONS["klipper"].cameras(RecordingHttp(body=body), {"base_url": "http://kl"}) == [], \
+        "a feed that stays WebRTC with no derivable MJPEG is skipped, never registered as a dead camera"
 
 
 async def test_klipper_without_webcams_api_exposes_nothing() -> None:
     assert await INTEGRATIONS["klipper"].cameras(RecordingHttp(status=404, body={}), {"base_url": "http://kl"}) == []
+
+
+@pytest.mark.parametrize(
+    "url, is_webrtc",
+    [
+        ("http://pi/webcam/webrtc", True),
+        ("webrtc://pi/stream", True),
+        ("whep://pi/whep", True),
+        ("/webcam/webrtc", True),
+        ("http://pi/webcam/?action=stream", False),
+        ("http://pi/webcam/?action=snapshot", False),
+        ("rtsp://pi:8554/stream.h264", False),
+        ("http://pi:8080/stream", False),
+    ],
+)
+def test_webrtc_endpoint_flags_only_uningestible_streams(url: str, is_webrtc: bool) -> None:
+    assert webrtc_endpoint(url) is is_webrtc
 
 
 BAMBU_CONFIG = {"host": "192.168.1.70", "serial": "01S00A", "access_code": "12345678"}

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -210,6 +210,28 @@ async def test_printer_camera_registers_cascades_and_is_managed(monkeypatch) -> 
         assert engine.cameras.get(camera.id) is None, "removing the printer drops its camera"
 
 
+async def test_camera_add_rejects_webrtc_url() -> None:
+    platform = FakePlatform()
+    async with running_engine(platform, camera_fps=[]) as (engine, events):
+        await engine.handle({"cmd": "camera.add", "name": "Cam", "source": {"kind": "url", "url": "http://pi/webcam/webrtc"}, "req_id": 5})
+        assert engine.cameras.values() == [], "a WebRTC stream is never registered as a camera"
+        assert any(e["event"] == "error" and e.get("req_id") == 5 and "WebRTC" in e["message"] for e in events)
+
+
+async def test_printer_webrtc_camera_warns_instead_of_silently_skipping(monkeypatch) -> None:
+    platform = FakePlatform()
+    async with running_engine(platform, camera_fps=[]) as (engine, events):
+        async def webrtc_cameras(http, config):
+            return [{"key": "webcam", "name": "Chamber", "source": {"kind": "url", "url": "http://pi/webcam/webrtc"}}]
+
+        monkeypatch.setattr(INTEGRATIONS["octoprint"], "cameras", webrtc_cameras)
+        await _register_printer(engine)
+        await asyncio.sleep(0.1)  # printer.add reconciles its cameras in the background
+        assert engine.cameras.values() == [], "a WebRTC feed exposed by a printer is not registered"
+        assert any(e["event"] == "warning" and "WebRTC" in e["message"] for e in events), \
+            "the user is told why a WebRTC feed was skipped rather than it silently no-opping"
+
+
 async def test_orphaned_managed_camera_can_be_removed() -> None:
     from printguard.engine.registry import Camera
 

--- a/uv.lock
+++ b/uv.lock
@@ -875,7 +875,7 @@ wheels = [
 
 [[package]]
 name = "printguard"
-version = "2.1.1"
+version = "2.1.2"
 source = { editable = "." }
 dependencies = [
     { name = "ai-edge-litert" },


### PR DESCRIPTION
PrintGuard reads cameras with PyAV/FFmpeg, which cannot ingest WebRTC (WHEP/WHIP). Crowsnest V5's camera-streamer advertises a WebRTC stream by default, so frame detection silently no-opped (issue #64).

- One shared predicate (engine/cameras.py: webrtc_endpoint) is the source of truth for "FFmpeg can't read this". A manually-added WebRTC URL is rejected with guidance, and a printer exposing a WebRTC-only webcam emits a warning instead of silently skipping, so no WebRTC source can register in either path.
- The Klipper adapter redirects a WebRTC webcam to its MJPEG sibling derived from the snapshot URL, and resolves relative webcam paths against the host's web port rather than Moonraker's API port (7125) — which routes no webcam paths and produced "no frames from camera".