### PR TITLE
v2.2.1 - One-container install & live auto-save

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 
 ### Changed
 
+- **One container, no second image, no terminal needed.** PrintGuard now ships as a **single
+  image** with the streaming server built in — there is no separate MediaMTX container to install
+  and no specific version of it to track down (the sticking point on Unraid and similar). Install
+  it with a single `docker run`, the now one-service `docker-compose.yaml`, or **one click from
+  Unraid Community Applications**. The hub still serves everything — dashboard, live video and all
+  — on `:8000`; the camera-publish ports `8554`/`1935` are optional and only matter if a camera
+  pushes a stream into PrintGuard. To put it on your network your own way — private over Tailscale,
+  public behind Cloudflare Access or an auth proxy — see the deployment guide.
+
+  *Upgrading from the two-container setup?* Pull the new image and remove the `mediamtx` service
+  (and its `mediamtx.yml` mount) from your compose file — the built-in server replaces it. Your
+  `/data` volume and settings carry over untouched.
+
 - **Settings now save themselves.** Camera image adjustments (brightness, contrast, sharpness,
   rotation, crop) and monitor settings (thresholds, sensitivity, defect response, notifications)
   now apply **live everywhere the moment you change them** — the camera preview, dashboard tiles

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ release notes.
 The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2026-06-25
+
+### Changed
+
+- **Settings now save themselves.** Camera image adjustments (brightness, contrast, sharpness,
+  rotation, crop) and monitor settings (thresholds, sensitivity, defect response, notifications),
+  along with your notification-channel and update preferences, now apply **live everywhere the
+  moment you change them** — the camera preview, dashboard tiles and risk gauges update as you
+  drag, with no **Save** button to remember. A small **saved ✓** indicator confirms each change
+  is stored, and anything still in flight is saved automatically when you close the panel. Printer
+  and Home Assistant (MQTT) connection settings keep an explicit **Save**, since they open a live
+  connection and shouldn't act on half-typed credentials.
+
 ## [2.2.0] - 2026-06-25
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,13 +12,13 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 ### Changed
 
 - **Settings now save themselves.** Camera image adjustments (brightness, contrast, sharpness,
-  rotation, crop) and monitor settings (thresholds, sensitivity, defect response, notifications),
-  along with your notification-channel and update preferences, now apply **live everywhere the
-  moment you change them** — the camera preview, dashboard tiles and risk gauges update as you
-  drag, with no **Save** button to remember. A small **saved ✓** indicator confirms each change
-  is stored, and anything still in flight is saved automatically when you close the panel. Printer
-  and Home Assistant (MQTT) connection settings keep an explicit **Save**, since they open a live
-  connection and shouldn't act on half-typed credentials.
+  rotation, crop) and monitor settings (thresholds, sensitivity, defect response, notifications)
+  now apply **live everywhere the moment you change them** — the camera preview, dashboard tiles
+  and risk gauges update as you drag, with no **Save** button to remember. A small **saved ✓**
+  indicator confirms each change is stored, and anything still in flight is saved automatically
+  when you close the panel. Notification channels, printers and Home Assistant (MQTT) keep an
+  explicit **Save**, since they hold credentials or open a live connection and shouldn't act on
+  half-typed input.
 
 ## [2.2.0] - 2026-06-25
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ Pyodide). No frames leave hardware the user owns.
 
 ```bash
 uv sync                                   # Python engine + hub server (use uv, never pip)
-uv run printguard                         # hub on :8000 (MediaMTX optional: docker compose up mediamtx)
+uv run printguard                         # hub on :8000 (MediaMTX is bundled into the image; for video in dev: brew install mediamtx && MEDIAMTX_BINARY=$(which mediamtx) uv run printguard)
 cd web && npm install && npm run dev      # UI hot-reload on :5173, proxied to :8000
 
 uv run pytest                             # engine simulation + adapter contract tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,7 +8,7 @@ PrintGuard runs in two modes: local (in-browser) and hub (server). The engine is
 
 ```bash
 uv sync                              # Python engine + hub server
-uv run printguard                    # hub on :8000 (MediaMTX optional: docker compose up mediamtx)
+uv run printguard                    # hub on :8000 (MediaMTX is bundled into the image; for video in dev, brew install mediamtx and set MEDIAMTX_BINARY=$(which mediamtx))
 cd web && npm install && npm run dev # UI with hot reload on :5173, proxied to :8000
 ```
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ COPY --from=mediamtx /mediamtx /usr/local/bin/mediamtx
 COPY printguard/ printguard/
 COPY models/ models/
 COPY mediamtx.yml mediamtx.yml
+COPY THIRD_PARTY_NOTICES.md THIRD_PARTY_NOTICES.md
 COPY --from=web /build/dist static/
 ENV PATH="/app/.venv/bin:$PATH" \
     MODEL_DIR=/app/models \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+FROM bluenviron/mediamtx:1.18.2 AS mediamtx
+
 FROM node:22-alpine AS web
 WORKDIR /build
 COPY web/package.json web/package-lock.json ./
@@ -16,13 +18,17 @@ RUN uv sync --frozen --no-dev --compile-bytecode
 FROM python:3.13-slim
 WORKDIR /app
 COPY --from=deps /app/.venv .venv
+COPY --from=mediamtx /mediamtx /usr/local/bin/mediamtx
 COPY printguard/ printguard/
 COPY models/ models/
+COPY mediamtx.yml mediamtx.yml
 COPY --from=web /build/dist static/
 ENV PATH="/app/.venv/bin:$PATH" \
     MODEL_DIR=/app/models \
     DATA_DIR=/data \
-    STATIC_DIR=/app/static
+    STATIC_DIR=/app/static \
+    MEDIAMTX_BINARY=/usr/local/bin/mediamtx \
+    MEDIAMTX_CONFIG=/app/mediamtx.yml
 VOLUME /data
-EXPOSE 8000
+EXPOSE 8000 8554 1935
 CMD ["printguard"]

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Open `http://<host>:8000`, pick a mode, register a camera and your printer, then
 that binds them.
 
 - **Unraid** — add **PrintGuard** from Community Applications (or import the
-  [template](unraid/printguard.xml)) and install from the UI; no terminal needed.
+  [template](templates/printguard.xml)) and install from the UI; no terminal needed.
 - **Docker Compose** — prefer a file? [`docker-compose.yaml`](docker-compose.yaml): `curl -fsSLO https://raw.githubusercontent.com/oliverbravery/PrintGuard/main/docker-compose.yaml && docker compose up -d`.
 
 Ports `8554`/`1935` only matter for cameras that *push* a stream into PrintGuard — most setups

--- a/README.md
+++ b/README.md
@@ -56,8 +56,7 @@ Open any monitor for its live risk score, score history and one-tap printer cont
 
 ## Quick start
 
-PrintGuard is a **single container** — the streaming server is built in, so there is no second
-image to install. One command, nothing to download:
+PrintGuard is a **single container** - Install with one command:
 
 ```bash
 docker run -d --name printguard --restart unless-stopped \
@@ -71,8 +70,7 @@ that binds them.
 
 - **Unraid** — add **PrintGuard** from Community Applications (or import the
   [template](unraid/printguard.xml)) and install from the UI; no terminal needed.
-- **Docker Compose** — prefer a file? [`docker-compose.yaml`](docker-compose.yaml) is now a single
-  service: `curl -fsSLO https://raw.githubusercontent.com/oliverbravery/PrintGuard/main/docker-compose.yaml && docker compose up -d`.
+- **Docker Compose** — prefer a file? [`docker-compose.yaml`](docker-compose.yaml): `curl -fsSLO https://raw.githubusercontent.com/oliverbravery/PrintGuard/main/docker-compose.yaml && docker compose up -d`.
 
 Ports `8554`/`1935` only matter for cameras that *push* a stream into PrintGuard — most setups
 (URL pull, Bambu, or "this device") can leave them off. Images for `amd64` and `arm64`

--- a/README.md
+++ b/README.md
@@ -56,16 +56,27 @@ Open any monitor for its live risk score, score history and one-tap printer cont
 
 ## Quick start
 
-Deploy with Docker Compose:
+PrintGuard is a **single container** — the streaming server is built in, so there is no second
+image to install. One command, nothing to download:
 
 ```bash
-curl -fsSLO https://raw.githubusercontent.com/oliverbravery/PrintGuard/main/docker-compose.yaml
-curl -fsSLO https://raw.githubusercontent.com/oliverbravery/PrintGuard/main/mediamtx.yml
-docker compose up -d
+docker run -d --name printguard --restart unless-stopped \
+  -p 8000:8000 -p 8554:8554 -p 1935:1935 \
+  -v printguard:/data \
+  ghcr.io/oliverbravery/printguard
 ```
 
 Open `http://<host>:8000`, pick a mode, register a camera and your printer, then add a monitor
-that binds them. Images for `amd64` and `arm64` (Raspberry Pi 4/5) are published to
+that binds them.
+
+- **Unraid** — add **PrintGuard** from Community Applications (or import the
+  [template](unraid/printguard.xml)) and install from the UI; no terminal needed.
+- **Docker Compose** — prefer a file? [`docker-compose.yaml`](docker-compose.yaml) is now a single
+  service: `curl -fsSLO https://raw.githubusercontent.com/oliverbravery/PrintGuard/main/docker-compose.yaml && docker compose up -d`.
+
+Ports `8554`/`1935` only matter for cameras that *push* a stream into PrintGuard — most setups
+(URL pull, Bambu, or "this device") can leave them off. Images for `amd64` and `arm64`
+(Raspberry Pi 4/5) are published to
 [`ghcr.io/oliverbravery/printguard`](https://github.com/oliverbravery/PrintGuard/pkgs/container/printguard)
 on every release.
 

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,34 @@
+# Third-party notices
+
+PrintGuard's Docker image bundles the following third-party software as a separate,
+unmodified binary (mere aggregation — it runs as its own process and is not linked into
+PrintGuard). Each is distributed under its own licence, reproduced below.
+
+## MediaMTX
+
+- Project: https://github.com/bluenviron/mediamtx
+- Licence: MIT
+
+```
+MIT License
+
+Copyright (c) 2019 aler9
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```

--- a/ca_profile.xml
+++ b/ca_profile.xml
@@ -1,0 +1,11 @@
+<CommunityApplications>
+  <Profile>
+**PrintGuard** watches your 3D-printer cameras with an on-device vision model, pauses or cancels the print the moment it starts to fail, and pushes a snapshot to your phone over ntfy, Telegram or Discord. No cloud and no account — camera frames never leave your server. Works with OctoPrint, Klipper (Moonraker) and Bambu Lab, and exposes every monitor to Home Assistant over MQTT.
+
+This repository publishes the official PrintGuard container template. The image is all-in-one — the streaming server is built in, so there is no second container to install.
+
+Support and docs: https://github.com/oliverbravery/PrintGuard
+  </Profile>
+  <Icon>https://raw.githubusercontent.com/oliverbravery/PrintGuard/main/web/public/apple-touch-icon.png</Icon>
+  <WebPage>https://github.com/oliverbravery/PrintGuard</WebPage>
+</CommunityApplications>

--- a/ca_profile.xml
+++ b/ca_profile.xml
@@ -2,7 +2,7 @@
   <Profile>
 **PrintGuard** watches your 3D-printer cameras with an on-device vision model, pauses or cancels the print the moment it starts to fail, and pushes a snapshot to your phone over ntfy, Telegram or Discord. No cloud and no account — camera frames never leave your server. Works with OctoPrint, Klipper (Moonraker) and Bambu Lab, and exposes every monitor to Home Assistant over MQTT.
 
-This repository publishes the official PrintGuard container template. The image is all-in-one — the streaming server is built in, so there is no second container to install.
+This repository publishes the official PrintGuard container template.
 
 Support and docs: https://github.com/oliverbravery/PrintGuard
   </Profile>

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,22 +5,9 @@ services:
     restart: unless-stopped
     ports:
       - "8000:8000"
-    environment:
-      MEDIAMTX_API: http://mediamtx:9997
-      MEDIAMTX_RTSP: rtsp://mediamtx:8554
-      MEDIAMTX_HLS: http://mediamtx:8888
+      - "8554:8554"
+      - "1935:1935"
     volumes:
       - ./data:/data
     extra_hosts:
       - "host.docker.internal:host-gateway"
-    depends_on:
-      - mediamtx
-
-  mediamtx:
-    image: bluenviron/mediamtx:1.18.2
-    restart: unless-stopped
-    ports:
-      - "8554:8554"
-      - "1935:1935"
-    volumes:
-      - ./mediamtx.yml:/mediamtx.yml

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -182,7 +182,7 @@ printguard/
     integrations/    printer service adapters (OctoPrint, Klipper, Bambu Lab, …)
     notifiers/       alert channel adapters (ntfy, Telegram, Discord, …)
     adapters.py      shared adapter contract (id, label, docs_url, JSON-schema config)
-  server/            hub platform: FastAPI, MediaMTX, LiteRT, PyAV
+  server/            hub platform: FastAPI, bundled MediaMTX (child process), LiteRT, PyAV
     api.py           REST API (/api/v1) over the engine protocol, scoped by token
     mcp.py           MCP server for agents, derived from the REST API
     mqtt.py          Home Assistant MQTT bridge (device discovery + two-way control)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,12 +1,13 @@
 # Deploying a hub securely
 
 A hub exposes everything a browser needs — dashboard, engine socket, live video and
-device publishing — on a single HTTP port, `:8000`. MediaMTX listens on `:8554`/`:1935`
-only so LAN cameras can push streams in; nothing else needs to be reachable. PrintGuard
-ships **no authentication**: anyone who can reach `:8000` sees every camera and can pause
-or cancel your printers. Never port-forward it from the internet — put one of the
-following in front instead. Each one carries full functionality, live video included,
-because video is plain HTTP through the same port.
+device publishing — on a single HTTP port, `:8000`. The streaming server is built into the
+same image and listens on `:8554`/`:1935` only so LAN cameras can push streams in (its
+control API and HLS muxer bind to localhost inside the container); nothing else needs to be
+reachable. PrintGuard ships **no authentication**: anyone who can reach `:8000` sees every
+camera and can pause or cancel your printers. Never port-forward it from the internet — put
+one of the following in front instead. Each one carries full functionality, live video
+included, because video is plain HTTP through the same port.
 
 ## Option 1 — Tailscale (recommended for private hubs)
 
@@ -97,9 +98,9 @@ public origin so the hub trusts it:
 - No router port-forwards for `8000`, `8554` or `1935`.
 - There are no per-user roles: anyone who authenticates sees every camera and can control
   every printer. Only let in people you would hand the printer to.
-- The MediaMTX API (`:9997`) and HLS muxer (`:8888`) are deliberately not published by
-  the compose file — the hub reaches them on the compose network, and the API can add
-  and remove streams.
+- The streaming server's control API (`:9997`) and HLS muxer (`:8888`) bind to `127.0.0.1`
+  inside the container, so they stay unreachable from outside even if a port is published —
+  the hub talks to them over loopback and proxies HLS out through `:8000`.
 - When a proxy on the same host is the only intended client, bind ports to
   `127.0.0.1:…` in the compose file.
 - WebSocket handshakes are origin-checked, so the auth proxy is not relied on to block

--- a/mediamtx.yml
+++ b/mediamtx.yml
@@ -1,5 +1,5 @@
 api: yes
-apiAddress: :9997
+apiAddress: 127.0.0.1:9997
 
 authInternalUsers:
   - user: any
@@ -11,12 +11,13 @@ authInternalUsers:
 
 rtsp: yes
 rtspAddress: :8554
+rtspTransports: [tcp]
 
 rtmp: yes
 rtmpAddress: :1935
 
 hls: yes
-hlsAddress: :8888
+hlsAddress: 127.0.0.1:8888
 hlsVariant: fmp4
 hlsSegmentCount: 3
 hlsSegmentDuration: 1s

--- a/printguard/server/app.py
+++ b/printguard/server/app.py
@@ -29,6 +29,7 @@ from ..engine.engine import Engine
 from ..pysrc import build_pysrc
 from .api import ApiAuth, build_api_app
 from .mcp import build_mcp_app
+from .mediamtx import EmbeddedMediaMTX
 from .mqtt import MqttBridge
 from .platform import ServerPlatform
 from .publish import ChunkStream, remux
@@ -63,6 +64,8 @@ def create_app() -> FastAPI:
     mediamtx_api = os.environ.get("MEDIAMTX_API", "http://localhost:9997")
     mediamtx_rtsp = os.environ.get("MEDIAMTX_RTSP", "rtsp://localhost:8554").rstrip("/")
     mediamtx_hls = os.environ.get("MEDIAMTX_HLS", "http://localhost:8888")
+    mediamtx_binary = os.environ.get("MEDIAMTX_BINARY")
+    mediamtx_config = os.environ.get("MEDIAMTX_CONFIG", str(REPO_ROOT / "mediamtx.yml"))
     allowed_origins = {o.strip().rstrip("/") for o in os.environ.get("PRINTGUARD_ORIGINS", "").split(",") if o.strip()}
     internal_token = secrets.token_urlsafe(32)
     api_auth = ApiAuth(internal_token)
@@ -71,6 +74,10 @@ def create_app() -> FastAPI:
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
+        streamer = None
+        if mediamtx_binary and Path(mediamtx_binary).exists():
+            streamer = EmbeddedMediaMTX(mediamtx_binary, mediamtx_config, mediamtx_api)
+            await streamer.start()
         platform = ServerPlatform(model_dir, data_dir, mediamtx_api, mediamtx_rtsp)
         engine = Engine(platform)
         await engine.start()
@@ -85,6 +92,8 @@ def create_app() -> FastAPI:
         await app.state.hls.aclose()
         await engine.stop()
         await platform.close()
+        if streamer is not None:
+            await streamer.stop()
 
     app = FastAPI(title="PrintGuard", lifespan=lifespan)
     pysrc = build_pysrc()

--- a/printguard/server/mediamtx.py
+++ b/printguard/server/mediamtx.py
@@ -1,13 +1,22 @@
-"""Thin client for the MediaMTX control API.
+"""Thin client for the MediaMTX control API and supervisor for a bundled binary.
 
 API reference: https://bluenviron.github.io/mediamtx/
 """
 
 from __future__ import annotations
 
+import asyncio
+import logging
 from typing import Any
+from urllib.parse import urlsplit
 
 import httpx
+
+logger = logging.getLogger(__name__)
+
+READY_TIMEOUT_S = 10.0
+RESTART_DELAY_S = 2.0
+STOP_TIMEOUT_S = 5.0
 
 
 class MediaMTX:
@@ -45,3 +54,63 @@ class MediaMTX:
     async def remove_path(self, name: str) -> None:
         """Deletes a managed path, ignoring paths that no longer exist."""
         await self._client.delete(f"{self._api}/v3/config/paths/delete/{name}", timeout=5.0)
+
+
+class EmbeddedMediaMTX:
+    """Supervises a MediaMTX binary bundled into the hub image.
+
+    The hub ships the streaming server inside its own image and runs it as a
+    child process, so a single container is the whole deployment instead of a
+    second image whose version may be unavailable on a given host. It starts
+    only when the image provides a binary path; pointed at an external MediaMTX
+    the hub uses that and this never runs. A server that exits is restarted and
+    the failure logged, because dropped streams must never pass silently.
+    """
+
+    def __init__(self, binary: str, config: str, api_base: str) -> None:
+        self._binary = binary
+        self._config = config
+        self._api = urlsplit(api_base)
+        self._process: asyncio.subprocess.Process | None = None
+        self._supervisor: asyncio.Task[None] | None = None
+        self._stopping = False
+
+    async def start(self) -> None:
+        """Launches the server and waits until its control API accepts connections."""
+        self._supervisor = asyncio.ensure_future(self._run())
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + READY_TIMEOUT_S
+        while loop.time() < deadline:
+            if await self._listening():
+                return
+            await asyncio.sleep(0.2)
+        logger.error("MediaMTX did not accept connections within %ss", READY_TIMEOUT_S)
+
+    async def _run(self) -> None:
+        while not self._stopping:
+            self._process = await asyncio.create_subprocess_exec(self._binary, self._config)
+            code = await self._process.wait()
+            if self._stopping:
+                return
+            logger.error("MediaMTX exited (code %s); restarting", code)
+            await asyncio.sleep(RESTART_DELAY_S)
+
+    async def _listening(self) -> bool:
+        try:
+            _, writer = await asyncio.open_connection(self._api.hostname, self._api.port)
+        except OSError:
+            return False
+        writer.close()
+        return True
+
+    async def stop(self) -> None:
+        """Stops supervising and terminates the server."""
+        self._stopping = True
+        if self._process is not None and self._process.returncode is None:
+            self._process.terminate()
+            try:
+                await asyncio.wait_for(self._process.wait(), STOP_TIMEOUT_S)
+            except asyncio.TimeoutError:
+                self._process.kill()
+        if self._supervisor is not None:
+            await self._supervisor

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "printguard"
-version = "2.2.0"
+version = "2.2.1"
 description = "Real-time 3D print failure detection"
 
 license = "GPL-2.0-only"

--- a/templates/printguard.xml
+++ b/templates/printguard.xml
@@ -12,7 +12,7 @@
   <Overview>PrintGuard watches your 3D-printer cameras with an on-device vision model, pauses or cancels the print the moment it starts to fail, and sends a snapshot to your phone over ntfy, Telegram or Discord. No cloud, no account &#8212; camera frames never leave your server. Works with OctoPrint, Klipper (Moonraker) and Bambu Lab, and publishes every monitor to Home Assistant over MQTT.&#13;&#10;&#13;&#10;Everything is in this one image &#8212; the streaming server is built in, so there is no second container to install. Open the WebUI, pick a mode, add a camera and printer, then create a monitor that binds them.&#13;&#10;&#13;&#10;PrintGuard ships no authentication: anyone who can reach the WebUI can control your printers. Keep it on your LAN, or put Tailscale / Cloudflare Access / an auth proxy in front before exposing it. See the deployment guide: https://github.com/oliverbravery/PrintGuard/blob/main/docs/deployment.md</Overview>
   <Category>HomeAutomation: Tools:</Category>
   <WebUI>http://[IP]:[PORT:8000]/</WebUI>
-  <TemplateURL>https://raw.githubusercontent.com/oliverbravery/PrintGuard/main/unraid/printguard.xml</TemplateURL>
+  <TemplateURL>https://raw.githubusercontent.com/oliverbravery/PrintGuard/main/templates/printguard.xml</TemplateURL>
   <Icon>https://raw.githubusercontent.com/oliverbravery/PrintGuard/main/web/public/apple-touch-icon.png</Icon>
   <ExtraParams>--add-host host.docker.internal:host-gateway</ExtraParams>
   <PostArgs/>

--- a/unraid/printguard.xml
+++ b/unraid/printguard.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<Container version="2">
+  <Name>PrintGuard</Name>
+  <Repository>ghcr.io/oliverbravery/printguard:latest</Repository>
+  <Registry>https://github.com/oliverbravery/PrintGuard/pkgs/container/printguard</Registry>
+  <Network>bridge</Network>
+  <MyIP/>
+  <Shell>sh</Shell>
+  <Privileged>false</Privileged>
+  <Support>https://github.com/oliverbravery/PrintGuard/issues</Support>
+  <Project>https://github.com/oliverbravery/PrintGuard</Project>
+  <Overview>PrintGuard watches your 3D-printer cameras with an on-device vision model, pauses or cancels the print the moment it starts to fail, and sends a snapshot to your phone over ntfy, Telegram or Discord. No cloud, no account &#8212; camera frames never leave your server. Works with OctoPrint, Klipper (Moonraker) and Bambu Lab, and publishes every monitor to Home Assistant over MQTT.&#13;&#10;&#13;&#10;Everything is in this one image &#8212; the streaming server is built in, so there is no second container to install. Open the WebUI, pick a mode, add a camera and printer, then create a monitor that binds them.&#13;&#10;&#13;&#10;PrintGuard ships no authentication: anyone who can reach the WebUI can control your printers. Keep it on your LAN, or put Tailscale / Cloudflare Access / an auth proxy in front before exposing it. See the deployment guide: https://github.com/oliverbravery/PrintGuard/blob/main/docs/deployment.md</Overview>
+  <Category>HomeAutomation: Tools:</Category>
+  <WebUI>http://[IP]:[PORT:8000]/</WebUI>
+  <TemplateURL>https://raw.githubusercontent.com/oliverbravery/PrintGuard/main/unraid/printguard.xml</TemplateURL>
+  <Icon>https://raw.githubusercontent.com/oliverbravery/PrintGuard/main/web/public/apple-touch-icon.png</Icon>
+  <ExtraParams>--add-host host.docker.internal:host-gateway</ExtraParams>
+  <PostArgs/>
+  <DonateText/>
+  <DonateLink/>
+  <Config Name="WebUI" Target="8000" Default="8000" Mode="tcp" Description="Dashboard, engine socket and live video (HTTP)" Type="Port" Display="always" Required="true" Mask="false">8000</Config>
+  <Config Name="Data" Target="/data" Default="/mnt/user/appdata/printguard" Mode="rw" Description="Stored settings and engine state" Type="Path" Display="always" Required="true" Mask="false">/mnt/user/appdata/printguard</Config>
+  <Config Name="Camera RTSP publish" Target="8554" Default="8554" Mode="tcp" Description="Optional: only needed for cameras that push an RTSP stream into PrintGuard" Type="Port" Display="advanced" Required="false" Mask="false">8554</Config>
+  <Config Name="Camera RTMP publish" Target="1935" Default="1935" Mode="tcp" Description="Optional: only needed for cameras that push an RTMP stream into PrintGuard" Type="Port" Display="advanced" Required="false" Mask="false">1935</Config>
+</Container>

--- a/uv.lock
+++ b/uv.lock
@@ -878,7 +878,7 @@ wheels = [
 
 [[package]]
 name = "printguard"
-version = "2.2.0"
+version = "2.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "ai-edge-litert" },

--- a/web/src/components/CamerasDialog.tsx
+++ b/web/src/components/CamerasDialog.tsx
@@ -6,6 +6,7 @@ import { publishStream, published, stopPublishing } from "../stream";
 import { sourceLabel } from "./CameraRail";
 import { CropEditor } from "./CropEditor";
 import { Dialog } from "./Dialog";
+import { SaveStatus } from "./SaveStatus";
 
 function slug(name: string): string {
   return name.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "") || "camera";
@@ -38,17 +39,10 @@ function Slider({
 }
 
 function CameraRow({ camera, focus }: { camera: Camera; focus: boolean }) {
-  const { engine, send, isPending } = useStore();
+  const { engine, send, isPending, updateCamera } = useStore();
   const [open, setOpen] = useState(focus);
   const ref = useRef<HTMLDivElement>(null);
   const owner = camera.printer_id ? engine?.printers.find((p) => p.id === camera.printer_id) : null;
-  const [draft, setDraft] = useState({
-    brightness: camera.brightness ?? 1,
-    contrast: camera.contrast ?? 1,
-    sharpness: camera.sharpness ?? 0,
-    crop: camera.crop ?? null,
-    rotation: camera.rotation ?? 0,
-  });
 
   useEffect(() => {
     if (focus) {
@@ -56,33 +50,6 @@ function CameraRow({ camera, focus }: { camera: Camera; focus: boolean }) {
       ref.current?.scrollIntoView({ behavior: "smooth", block: "center" });
     }
   }, [focus]);
-
-  useEffect(() => {
-    setDraft({
-      brightness: camera.brightness ?? 1,
-      contrast: camera.contrast ?? 1,
-      sharpness: camera.sharpness ?? 0,
-      crop: camera.crop ?? null,
-      rotation: camera.rotation ?? 0,
-    });
-  }, [camera.id]);
-
-  const dirty =
-    draft.brightness !== (camera.brightness ?? 1) ||
-    draft.contrast !== (camera.contrast ?? 1) ||
-    draft.sharpness !== (camera.sharpness ?? 0) ||
-    draft.rotation !== (camera.rotation ?? 0) ||
-    JSON.stringify(draft.crop) !== JSON.stringify(camera.crop ?? null);
-
-  const save = () => send({ cmd: "camera.update", id: camera.id, patch: draft });
-  const reset = () =>
-    setDraft({
-      brightness: camera.brightness ?? 1,
-      contrast: camera.contrast ?? 1,
-      sharpness: camera.sharpness ?? 0,
-      crop: camera.crop ?? null,
-      rotation: camera.rotation ?? 0,
-    });
 
   return (
     <div ref={ref} className="panel overflow-hidden">
@@ -117,27 +84,27 @@ function CameraRow({ camera, focus }: { camera: Camera; focus: boolean }) {
         <div className="px-3 pb-3 pt-1 border-t border-line-0 space-y-3">
           <Slider
             label="Brightness"
-            value={draft.brightness}
+            value={camera.brightness ?? 1}
             min={0.25}
             max={2}
             step={0.05}
-            onChange={(v) => setDraft((d) => ({ ...d, brightness: v }))}
+            onChange={(v) => updateCamera(camera.id, { brightness: v })}
           />
           <Slider
             label="Contrast"
-            value={draft.contrast}
+            value={camera.contrast ?? 1}
             min={0.25}
             max={2}
             step={0.05}
-            onChange={(v) => setDraft((d) => ({ ...d, contrast: v }))}
+            onChange={(v) => updateCamera(camera.id, { contrast: v })}
           />
           <Slider
             label="Sharpness"
-            value={draft.sharpness}
+            value={camera.sharpness ?? 0}
             min={0}
             max={2}
             step={0.1}
-            onChange={(v) => setDraft((d) => ({ ...d, sharpness: v }))}
+            onChange={(v) => updateCamera(camera.id, { sharpness: v })}
           />
           <div className="space-y-1.5">
             <span className="label">Rotation</span>
@@ -145,8 +112,8 @@ function CameraRow({ camera, focus }: { camera: Camera; focus: boolean }) {
               {[0, 90, 180, 270].map((deg) => (
                 <button
                   key={deg}
-                  className={`btn flex-1 !py-1.5 !text-[0.66rem] ${draft.rotation === deg ? "!border-accent !text-accent" : ""}`}
-                  onClick={() => setDraft((d) => ({ ...d, rotation: deg }))}
+                  className={`btn flex-1 !py-1.5 !text-[0.66rem] ${(camera.rotation ?? 0) === deg ? "!border-accent !text-accent" : ""}`}
+                  onClick={() => updateCamera(camera.id, { rotation: deg })}
                 >
                   {deg}°
                 </button>
@@ -156,21 +123,12 @@ function CameraRow({ camera, focus }: { camera: Camera; focus: boolean }) {
           <CropEditor
             camera={camera}
             mode={engine?.mode ?? "local"}
-            crop={draft.crop}
-            rotation={draft.rotation}
-            onChange={(crop) => setDraft((d) => ({ ...d, crop }))}
+            crop={camera.crop ?? null}
+            rotation={camera.rotation ?? 0}
+            onChange={(crop) => updateCamera(camera.id, { crop })}
           />
-          <div className="flex gap-2">
-            <button
-              className="btn btn-primary flex-1 !py-1.5"
-              disabled={!dirty || isPending("camera.update")}
-              onClick={save}
-            >
-              {isPending("camera.update") ? "Saving…" : "Save"}
-            </button>
-            <button className="btn !py-1.5" disabled={!dirty} onClick={reset}>
-              Reset
-            </button>
+          <div className="flex justify-end pt-1">
+            <SaveStatus />
           </div>
         </div>
       )}

--- a/web/src/components/DetailPanel.tsx
+++ b/web/src/components/DetailPanel.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useId, useRef, useState } from "react";
+import { useEffect, useId, useRef } from "react";
 import { useStore } from "../store";
 import type { Monitor } from "../types";
 import { Modal } from "./Dialog";
 import { Feed } from "./Feed";
 import { DeviceChip } from "./MonitorTile";
 import { RiskGauge } from "./RiskGauge";
+import { SaveStatus } from "./SaveStatus";
 import { Sparkline } from "./Sparkline";
 import { Toggle } from "./Toggle";
 
@@ -44,20 +45,15 @@ function Slider({
 }
 
 export function DetailPanel({ monitor }: { monitor: Monitor }) {
-  const { engine, history, send, openDetail, openDialog, isPending } = useStore();
-  const [draft, setDraft] = useState(monitor);
+  const { engine, history, send, openDetail, openDialog, isPending, updateMonitor } = useStore();
   const titleId = useId();
   const actionRef = useRef<string | null>(null);
-  const saveRef = useRef<string | null>(null);
-  useEffect(() => setDraft(monitor), [monitor.id]);
-
-  const updating = isPending("monitor.update");
+  const removeRef = useRef(false);
   const removing = isPending("monitor.remove");
 
   useEffect(() => {
-    if (saveRef.current === "monitor.update" && !updating) close();
-    if (saveRef.current === "monitor.remove" && !removing) close();
-  }, [updating, removing]);
+    if (removeRef.current && !removing) close();
+  }, [removing]);
 
   const camera = engine?.cameras.find((c) => c.id === monitor.camera_id);
   const printer = engine?.printers.find((p) => p.id === monitor.printer_id);
@@ -66,8 +62,6 @@ export function DetailPanel({ monitor }: { monitor: Monitor }) {
   const score = points.at(-1)?.score ?? 0;
   const linked = Boolean(printer);
   const close = () => openDetail(null);
-
-  const patch = (fields: Partial<Monitor>) => setDraft((d) => ({ ...d, ...fields }));
 
   return (
     <Modal onClose={close} variant="sheet" labelledBy={titleId}>
@@ -135,7 +129,7 @@ export function DetailPanel({ monitor }: { monitor: Monitor }) {
 
         <Section title="Monitoring">
           <div className="space-y-4">
-            <Toggle label="Watch this monitor" on={draft.enabled} onChange={(v) => patch({ enabled: v })} />
+            <Toggle label="Watch this monitor" on={monitor.enabled} onChange={(v) => updateMonitor(monitor.id, { enabled: v })} />
             {monitor.enabled && monitor.watching === false && (
               <p className="mono text-[0.7rem] text-text-2">
                 standby — printer is {printer?.device_state?.status ?? "not printing"}; inference resumes when it prints
@@ -143,7 +137,7 @@ export function DetailPanel({ monitor }: { monitor: Monitor }) {
             )}
             <label className="block">
               <span className="label block mb-1">Camera</span>
-              <select className="field" value={draft.camera_id} onChange={(e) => patch({ camera_id: e.target.value })}>
+              <select className="field" value={monitor.camera_id} onChange={(e) => updateMonitor(monitor.id, { camera_id: e.target.value })}>
                 <option value="">No camera</option>
                 {(engine?.cameras ?? []).map((c) => (
                   <option key={c.id} value={c.id}>
@@ -152,20 +146,20 @@ export function DetailPanel({ monitor }: { monitor: Monitor }) {
                 ))}
               </select>
             </label>
-            <Slider label="Alert threshold" value={draft.threshold} min={0.05} max={1} step={0.01} onChange={(v) => patch({ threshold: v })} />
-            <Slider label="Sensitivity" value={draft.sensitivity} min={0.2} max={5} step={0.1} onChange={(v) => patch({ sensitivity: v })} />
+            <Slider label="Alert threshold" value={monitor.threshold} min={0.05} max={1} step={0.01} onChange={(v) => updateMonitor(monitor.id, { threshold: v })} />
+            <Slider label="Sensitivity" value={monitor.sensitivity} min={0.2} max={5} step={0.1} onChange={(v) => updateMonitor(monitor.id, { sensitivity: v })} />
             <label className="block">
               <div className="flex justify-between mb-1">
                 <span className="label">Consecutive detections to alert</span>
-                <span className="mono text-[0.72rem]">{draft.consecutive}</span>
+                <span className="mono text-[0.72rem]">{monitor.consecutive}</span>
               </div>
               <input
                 type="range"
                 min={1}
                 max={15}
                 step={1}
-                value={draft.consecutive}
-                onChange={(e) => patch({ consecutive: Number(e.target.value) })}
+                value={monitor.consecutive}
+                onChange={(e) => updateMonitor(monitor.id, { consecutive: Number(e.target.value) })}
               />
             </label>
           </div>
@@ -175,7 +169,7 @@ export function DetailPanel({ monitor }: { monitor: Monitor }) {
           <div className="space-y-4">
             <label className="block">
               <span className="label block mb-1">On sustained defect</span>
-              <select className="field" value={draft.on_defect} onChange={(e) => patch({ on_defect: e.target.value as Monitor["on_defect"] })}>
+              <select className="field" value={monitor.on_defect} onChange={(e) => updateMonitor(monitor.id, { on_defect: e.target.value as Monitor["on_defect"] })}>
                 <option value="none">Alert only</option>
                 <option value="pause">Pause the print</option>
                 <option value="cancel">Cancel the print</option>
@@ -184,24 +178,24 @@ export function DetailPanel({ monitor }: { monitor: Monitor }) {
             <label className="block">
               <div className="flex justify-between mb-1">
                 <span className="label">Cooldown (seconds)</span>
-                <span className="mono text-[0.72rem]">{draft.cooldown_s}</span>
+                <span className="mono text-[0.72rem]">{monitor.cooldown_s}</span>
               </div>
               <input
                 type="range"
                 min={0}
                 max={600}
                 step={10}
-                value={draft.cooldown_s}
-                onChange={(e) => patch({ cooldown_s: Number(e.target.value) })}
+                value={monitor.cooldown_s}
+                onChange={(e) => updateMonitor(monitor.id, { cooldown_s: Number(e.target.value) })}
               />
             </label>
-            <Toggle label="Push notifications" on={draft.notify} onChange={(v) => patch({ notify: v })} />
+            <Toggle label="Push notifications" on={monitor.notify} onChange={(v) => updateMonitor(monitor.id, { notify: v })} />
           </div>
         </Section>
 
         <Section title="Printer">
           <div className="space-y-3">
-            <select className="field" value={draft.printer_id} onChange={(e) => patch({ printer_id: e.target.value })}>
+            <select className="field" value={monitor.printer_id} onChange={(e) => updateMonitor(monitor.id, { printer_id: e.target.value })}>
               <option value="">No printer (alerts only)</option>
               {printers.map((p) => (
                 <option key={p.id} value={p.id}>
@@ -215,22 +209,14 @@ export function DetailPanel({ monitor }: { monitor: Monitor }) {
           </div>
         </Section>
 
-        <div className="px-5 py-4 flex gap-2.5">
-          <button
-            className="btn btn-primary flex-1"
-            disabled={updating}
-            onClick={() => {
-              saveRef.current = "monitor.update";
-              send({ cmd: "monitor.update", id: monitor.id, patch: draft });
-            }}
-          >
-            {updating ? "Saving…" : "Save"}
-          </button>
+        <div className="px-5 py-4 flex items-center gap-2.5">
+          <SaveStatus />
+          <div className="flex-1" />
           <button
             className="btn btn-danger"
             disabled={removing}
             onClick={() => {
-              saveRef.current = "monitor.remove";
+              removeRef.current = true;
               send({ cmd: "monitor.remove", id: monitor.id });
             }}
           >

--- a/web/src/components/SaveStatus.tsx
+++ b/web/src/components/SaveStatus.tsx
@@ -6,7 +6,7 @@ export function SaveStatus() {
     return <span className="mono text-[0.62rem] text-text-2 boot-cursor">saving</span>;
   }
   if (savedAt) {
-    const time = new Date(savedAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+    const time = new Date(savedAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit", second: "2-digit" });
     return <span className="chip chip-ok">saved ✓ {time}</span>;
   }
   return null;

--- a/web/src/components/SaveStatus.tsx
+++ b/web/src/components/SaveStatus.tsx
@@ -1,0 +1,13 @@
+import { useStore } from "../store";
+
+export function SaveStatus() {
+  const { optimistic, savedAt } = useStore();
+  if (Object.keys(optimistic).length > 0) {
+    return <span className="mono text-[0.62rem] text-text-2 boot-cursor">saving</span>;
+  }
+  if (savedAt) {
+    const time = new Date(savedAt).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+    return <span className="chip chip-ok">saved ✓ {time}</span>;
+  }
+  return null;
+}

--- a/web/src/components/SettingsDialog.tsx
+++ b/web/src/components/SettingsDialog.tsx
@@ -1,8 +1,9 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { useStore } from "../store";
 import { applyTheme, beginPreview, endPreview, PALETTES } from "../theme";
 import type { ApiToken, CustomTheme, MqttConfig, ThemeBase, ThemeTokenKey } from "../types";
 import { Dialog } from "./Dialog";
+import { SaveStatus } from "./SaveStatus";
 import { SchemaForm } from "./SchemaForm";
 import { ThemeEditor } from "./ThemeEditor";
 import { Toggle } from "./Toggle";
@@ -26,16 +27,14 @@ function Swatch({ colors }: { colors: CustomTheme["colors"] }) {
 }
 
 export function SettingsDialog() {
-  const { engine, send, openDialog, leaveMode, isPending, notifyTest, testingNotifier, testNotifier, createdToken, clearCreatedToken } = useStore();
-  const [notifiers, setNotifiers] = useState(engine?.settings.notifiers ?? {});
-  const [updateCheck, setUpdateCheck] = useState(engine?.settings.update_check ?? true);
+  const { engine, send, openDialog, leaveMode, isPending, notifyTest, testingNotifier, testNotifier, createdToken, clearCreatedToken, updateSettings } = useStore();
+  const notifiers = engine?.settings.notifiers ?? {};
+  const updateCheck = engine?.settings.update_check ?? true;
   const [mqtt, setMqtt] = useState<MqttConfig>(engine?.settings.mqtt ?? {});
   const setMqttField = (key: keyof MqttConfig, value: MqttConfig[keyof MqttConfig]) => setMqtt({ ...mqtt, [key]: value });
   const [tokenName, setTokenName] = useState("");
   const [tokenScope, setTokenScope] = useState<ApiToken["scope"]>("read");
   const [tab, setTab] = useState<TabId>("alerts");
-  const saving = isPending("settings.update");
-  const sent = useRef(false);
   const close = () => openDialog(null);
   const tokens = engine?.tokens ?? [];
 
@@ -70,10 +69,6 @@ export function SettingsDialog() {
     applyTheme(selection, next, true);
     send({ cmd: "settings.update", patch: { themes: next, theme: selection } });
   };
-
-  useEffect(() => {
-    if (sent.current && !saving) close();
-  }, [saving]);
 
   useEffect(() => {
     if (!editing) return;
@@ -216,7 +211,7 @@ export function SettingsDialog() {
                       const next = { ...notifiers };
                       if (on) next[meta.id] = next[meta.id] ?? {};
                       else delete next[meta.id];
-                      setNotifiers(next);
+                      updateSettings({ notifiers: next });
                     }}
                   />
                   {enabled && (
@@ -224,7 +219,7 @@ export function SettingsDialog() {
                       <SchemaForm
                         meta={meta}
                         value={notifiers[meta.id]}
-                        onChange={(config) => setNotifiers({ ...notifiers, [meta.id]: config })}
+                        onChange={(config) => updateSettings({ notifiers: { ...notifiers, [meta.id]: config } })}
                       />
                       <div className="flex items-center gap-3">
                         <button
@@ -248,6 +243,9 @@ export function SettingsDialog() {
             <span className="text-[0.7rem] text-text-2 block">
               Defect alerts (with snapshots) go to every enabled channel for printers with notifications on.
             </span>
+            <div className="flex justify-end">
+              <SaveStatus />
+            </div>
           </div>
         )}
 
@@ -309,6 +307,16 @@ export function SettingsDialog() {
                 </span>
               </div>
             )}
+            <button
+              className="btn btn-primary w-full"
+              disabled={isPending("settings.update")}
+              onClick={() => send({ cmd: "settings.update", patch: { mqtt } })}
+            >
+              {isPending("settings.update") ? "Saving…" : "Save broker settings"}
+            </button>
+            <span className="text-[0.7rem] text-text-2 block">
+              Broker settings open a live connection, so they apply on Save rather than automatically.
+            </span>
           </div>
         )}
 
@@ -319,7 +327,7 @@ export function SettingsDialog() {
               label="Automatically check for updates"
               on={updateCheck}
               onChange={(on) => {
-                setUpdateCheck(on);
+                updateSettings({ update_check: on });
                 if (on && !engine?.update) send({ cmd: "update.check" });
               }}
             />
@@ -339,6 +347,9 @@ export function SettingsDialog() {
                 {engine?.version && `v${engine.version}`}
                 {engine?.update && !engine.update.available && " · up to date"}
               </span>
+            </div>
+            <div className="flex justify-end">
+              <SaveStatus />
             </div>
           </div>
         )}
@@ -422,19 +433,6 @@ export function SettingsDialog() {
               </div>
             </div>
           </div>
-        )}
-
-        {tab !== "api" && tab !== "appearance" && (
-          <button
-            className="btn btn-primary w-full"
-            disabled={saving}
-            onClick={() => {
-              sent.current = true;
-              send({ cmd: "settings.update", patch: { notifiers, update_check: updateCheck, mqtt } });
-            }}
-          >
-            {saving ? "Saving…" : "Save"}
-          </button>
         )}
 
         <div className="hairline pt-4 flex items-center justify-between">

--- a/web/src/components/SettingsDialog.tsx
+++ b/web/src/components/SettingsDialog.tsx
@@ -28,7 +28,7 @@ function Swatch({ colors }: { colors: CustomTheme["colors"] }) {
 
 export function SettingsDialog() {
   const { engine, send, openDialog, leaveMode, isPending, notifyTest, testingNotifier, testNotifier, createdToken, clearCreatedToken, updateSettings } = useStore();
-  const notifiers = engine?.settings.notifiers ?? {};
+  const [notifiers, setNotifiers] = useState(engine?.settings.notifiers ?? {});
   const updateCheck = engine?.settings.update_check ?? true;
   const [mqtt, setMqtt] = useState<MqttConfig>(engine?.settings.mqtt ?? {});
   const setMqttField = (key: keyof MqttConfig, value: MqttConfig[keyof MqttConfig]) => setMqtt({ ...mqtt, [key]: value });
@@ -211,7 +211,7 @@ export function SettingsDialog() {
                       const next = { ...notifiers };
                       if (on) next[meta.id] = next[meta.id] ?? {};
                       else delete next[meta.id];
-                      updateSettings({ notifiers: next });
+                      setNotifiers(next);
                     }}
                   />
                   {enabled && (
@@ -219,7 +219,7 @@ export function SettingsDialog() {
                       <SchemaForm
                         meta={meta}
                         value={notifiers[meta.id]}
-                        onChange={(config) => updateSettings({ notifiers: { ...notifiers, [meta.id]: config } })}
+                        onChange={(config) => setNotifiers({ ...notifiers, [meta.id]: config })}
                       />
                       <div className="flex items-center gap-3">
                         <button
@@ -243,9 +243,16 @@ export function SettingsDialog() {
             <span className="text-[0.7rem] text-text-2 block">
               Defect alerts (with snapshots) go to every enabled channel for printers with notifications on.
             </span>
-            <div className="flex justify-end">
-              <SaveStatus />
-            </div>
+            <button
+              className="btn btn-primary w-full"
+              disabled={isPending("settings.update")}
+              onClick={() => send({ cmd: "settings.update", patch: { notifiers } })}
+            >
+              {isPending("settings.update") ? "Saving…" : "Save channels"}
+            </button>
+            <span className="text-[0.7rem] text-text-2 block">
+              Channels hold credentials, so they apply on Save rather than automatically.
+            </span>
           </div>
         )}
 

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -3,9 +3,37 @@ import { currentLayout } from "./layout";
 import { bootLocal } from "./local";
 import { resumePublishers } from "./stream";
 import { applyTheme } from "./theme";
-import type { CameraSource, EngineLink, EngineState, Layout, LayoutSection, Mode, ScorePoint } from "./types";
+import type { Camera, CameraSource, EngineLink, EngineState, Layout, LayoutSection, Mode, Monitor, ScorePoint } from "./types";
 
 const HISTORY_LIMIT = 240;
+const UPDATE_DEBOUNCE_MS = 250;
+const updateTimers: Record<string, ReturnType<typeof setTimeout>> = {};
+
+type OptimisticKind = "camera" | "monitor" | "settings";
+
+interface OptimisticEntry {
+  kind: OptimisticKind;
+  id?: string;
+  patch: Record<string, unknown>;
+  reqId: number | null;
+}
+
+function applyOptimistic(engine: EngineState, overlay: Record<string, OptimisticEntry>): EngineState {
+  let cameras = engine.cameras;
+  let monitors = engine.monitors;
+  let settings = engine.settings;
+  for (const entry of Object.values(overlay)) {
+    if (entry.kind === "camera") cameras = cameras.map((c) => (c.id === entry.id ? ({ ...c, ...entry.patch } as Camera) : c));
+    else if (entry.kind === "monitor") monitors = monitors.map((m) => (m.id === entry.id ? ({ ...m, ...entry.patch } as Monitor) : m));
+    else settings = { ...settings, ...entry.patch } as EngineState["settings"];
+  }
+  return { ...engine, cameras, monitors, settings };
+}
+
+function commandFor(entry: OptimisticEntry): Record<string, unknown> {
+  if (entry.kind === "settings") return { cmd: "settings.update", patch: entry.patch };
+  return { cmd: `${entry.kind}.update`, id: entry.id, patch: entry.patch };
+}
 
 function modeFromUrl(): Mode | null {
   const hash = location.hash.slice(1);
@@ -40,13 +68,19 @@ interface PgStore {
   focusCameraId: string | null;
   createdToken: { name: string; secret: string } | null;
   customising: boolean;
+  optimistic: Record<string, OptimisticEntry>;
+  savedAt: number | null;
   setCustomising(on: boolean): void;
   mutateLayout(key: keyof Layout, fn: (section: LayoutSection) => LayoutSection): void;
   resetLayout(): void;
   chooseMode(mode: Mode): void;
   leaveMode(): void;
-  send(cmd: Record<string, unknown>): void;
+  send(cmd: Record<string, unknown>): number;
   isPending(cmd: string): boolean;
+  updateCamera(id: string, patch: Record<string, unknown>): void;
+  updateMonitor(id: string, patch: Record<string, unknown>): void;
+  updateSettings(patch: Record<string, unknown>): void;
+  flushUpdates(): void;
   discover(): void;
   openDialog(dialog: DialogKind, focusCameraId?: string | null): void;
   openDetail(id: string | null): void;
@@ -95,16 +129,48 @@ export const useStore = create<PgStore>((set, get) => {
     });
   };
 
+  const sendSilent = (cmd: Record<string, unknown>): number => {
+    const req_id = ++reqSeq;
+    get().link?.send({ ...cmd, req_id });
+    return req_id;
+  };
+
+  const flushKey = (key: string) => {
+    delete updateTimers[key];
+    const entry = get().optimistic[key];
+    if (!entry) return;
+    const reqId = sendSilent(commandFor(entry));
+    set((s) => (s.optimistic[key] ? { optimistic: { ...s.optimistic, [key]: { ...s.optimistic[key], reqId } } } : s));
+  };
+
+  const queueUpdate = (key: string, kind: OptimisticKind, id: string | undefined, patch: Record<string, unknown>) => {
+    set((s) => {
+      const prev = s.optimistic[key];
+      const entry: OptimisticEntry = { kind, id, patch: { ...(prev?.patch ?? {}), ...patch }, reqId: null };
+      const optimistic = { ...s.optimistic, [key]: entry };
+      return { optimistic, savedAt: null, engine: s.engine ? applyOptimistic(s.engine, optimistic) : s.engine };
+    });
+    clearTimeout(updateTimers[key]);
+    updateTimers[key] = setTimeout(() => flushKey(key), UPDATE_DEBOUNCE_MS);
+  };
+
   const onEvent = (event: any) => {
     switch (event.event) {
       case "state": {
         clearPending(event.req_id);
-        const settings = (event as EngineState).settings;
-        applyTheme(settings?.theme ?? "system", settings?.themes ?? []);
-        set({ engine: event as EngineState, phase: "ready" });
+        const server = event as EngineState;
+        let optimistic = get().optimistic;
+        const had = Object.keys(optimistic).length > 0;
+        if (event.req_id != null && had) {
+          optimistic = Object.fromEntries(Object.entries(optimistic).filter(([, e]) => e.reqId !== event.req_id));
+        }
+        const cleared = had && Object.keys(optimistic).length === 0;
+        const engine = Object.keys(optimistic).length ? applyOptimistic(server, optimistic) : server;
+        applyTheme(server.settings?.theme ?? "system", server.settings?.themes ?? []);
+        set({ engine, optimistic, phase: "ready", ...(cleared ? { savedAt: Date.now() } : {}) });
         if (!resumed && get().mode === "hub") {
           resumed = true;
-          void resumePublishers((event as EngineState).cameras, (reason) => get().toast("error", `publishing stopped: ${reason}`));
+          void resumePublishers(server.cameras, (reason) => get().toast("error", `publishing stopped: ${reason}`));
         }
         break;
       }
@@ -154,7 +220,15 @@ export const useStore = create<PgStore>((set, get) => {
       case "error":
         get().toast("error", event.message);
         clearPending(event.req_id);
-        set({ discovering: false, testing: false, testingNotifier: null });
+        set((s) => ({
+          discovering: false,
+          testing: false,
+          testingNotifier: null,
+          optimistic:
+            event.req_id != null
+              ? Object.fromEntries(Object.entries(s.optimistic).filter(([, e]) => e.reqId !== event.req_id))
+              : s.optimistic,
+        }));
         break;
     }
   };
@@ -198,6 +272,8 @@ export const useStore = create<PgStore>((set, get) => {
     focusCameraId: null,
     createdToken: null,
     customising: false,
+    optimistic: {},
+    savedAt: null,
 
     setCustomising(on) {
       set({ customising: on });
@@ -225,6 +301,7 @@ export const useStore = create<PgStore>((set, get) => {
     },
 
     leaveMode() {
+      get().flushUpdates();
       location.assign(location.pathname);
     },
 
@@ -233,10 +310,30 @@ export const useStore = create<PgStore>((set, get) => {
       const cmdType = cmd.cmd as string;
       set((s) => ({ pending: { ...s.pending, [cmdType]: { req_id, cmd: cmdType } } }));
       get().link?.send({ ...cmd, req_id });
+      return req_id;
     },
 
     isPending(cmd) {
       return cmd in get().pending;
+    },
+
+    updateCamera(id, patch) {
+      queueUpdate(`camera:${id}`, "camera", id, patch);
+    },
+
+    updateMonitor(id, patch) {
+      queueUpdate(`monitor:${id}`, "monitor", id, patch);
+    },
+
+    updateSettings(patch) {
+      queueUpdate("settings", "settings", undefined, patch);
+    },
+
+    flushUpdates() {
+      for (const key of Object.keys(updateTimers)) {
+        clearTimeout(updateTimers[key]);
+        flushKey(key);
+      }
     },
 
     discover() {
@@ -245,10 +342,12 @@ export const useStore = create<PgStore>((set, get) => {
     },
 
     openDialog(dialog, focusCameraId = null) {
+      get().flushUpdates();
       set({ dialog, discovered: null, printerTest: null, notifyTest: null, focusCameraId, createdToken: null });
     },
 
     openDetail(detailId) {
+      get().flushUpdates();
       set({ detailId, printerTest: null });
     },
 


### PR DESCRIPTION
Version 2.2.1 makes PrintGuard far easier to install, and makes settings save themselves.

- [x] **Single-container install** — MediaMTX is now bundled into the one image and supervised as a child process, so there's no second container to install and no specific MediaMTX version to track down (the sticking point on Unraid and similar). Install with one `docker run`, the now one-service `docker-compose.yaml`, or one click from Unraid Community Applications.
- [x] **Unraid Community Applications template** (`templates/printguard.xml`) plus `ca_profile.xml`, laid out per Unraid's starter for one-click, no-terminal install
- [x] **Streaming server hardened** — its control API and HLS muxer bind to loopback, and RTSP is TCP-only (no stray UDP listener); only `:8000` (and optionally the camera-publish ports `8554`/`1935`) need exposing
- [x] **MediaMTX MIT licence bundled** with the image (`THIRD_PARTY_NOTICES.md`) — shipped as a separate unmodified binary (mere aggregation), GPL-2.0-compatible
- [x] **Live auto-save** for camera, monitor and alert settings — changes apply everywhere the moment you make them, with a `saved ✓` indicator; credential-bearing forms (notifiers, printers, MQTT) keep an explicit **Save**

**Upgrading from the two-container setup:** pull the new image and remove the `mediamtx` service (and its `mediamtx.yml` mount) from your compose file — the built-in server replaces it. Your `/data` volume and settings carry over untouched.
