### PR TITLE
Fix Bambu A1/P1 live MJPEG camera probing

### DIFF
--- a/printguard/server/platform.py
+++ b/printguard/server/platform.py
@@ -29,6 +29,10 @@ FPS_SAMPLE_FRAMES = 25
 MEASURE_WARMUP_S = 1.0
 OPEN_WAIT_S = 8.0
 RECONNECT_DELAY_S = 3.0
+# Callable sources are live MJPEG pipes, such as Bambu A1/P1 cameras. Keep
+# probing short so av.open() identifies the stream instead of consuming frames
+# indefinitely before returning.
+MJPEG_LIVE_OPTIONS = {"analyzeduration": "0", "probesize": "32"}
 
 
 class AVSource:
@@ -56,7 +60,7 @@ class AVSource:
         """Opens the container, returning it and any pipe to close afterwards."""
         if not isinstance(self._source, str):
             pipe = self._source()
-            return av.open(pipe, format="mjpeg", options={"analyzeduration": "0"}), pipe
+            return av.open(pipe, format="mjpeg", options=MJPEG_LIVE_OPTIONS), pipe
         options = {}
         if self._source.startswith("rtsp://"):
             options["rtsp_transport"] = "tcp"

--- a/tests/test_server_platform.py
+++ b/tests/test_server_platform.py
@@ -1,0 +1,32 @@
+"""Server platform stream handling."""
+
+from __future__ import annotations
+
+
+def test_callable_mjpeg_sources_limit_pyav_probe(monkeypatch) -> None:
+    from printguard.server import platform
+
+    opened = []
+
+    class Pipe:
+        pass
+
+    pipe = Pipe()
+
+    def fake_open(target, *, format, options, **kwargs):
+        opened.append((target, format, options))
+        return "container"
+
+    monkeypatch.setattr(platform.av, "open", fake_open)
+
+    source = object.__new__(platform.AVSource)
+    source._source = lambda: pipe
+    source._publish_url = None
+
+    container, returned_pipe = source._open()
+
+    assert container == "container"
+    assert returned_pipe is pipe
+    assert opened == [(pipe, "mjpeg", platform.MJPEG_LIVE_OPTIONS)]
+    assert opened[0][2]["analyzeduration"] == "0"
+    assert opened[0][2]["probesize"] == "32"


### PR DESCRIPTION
## Summary

Fixes Bambu A1/P1 printer camera registration hanging during live MJPEG probing. The Bambu port-6000 reader can return valid JPEG frames, but `av.open()` may continue probing indefinitely with the previous options, so printer camera refresh never registers the chamber camera.

This change adds a small `probesize` limit for callable live MJPEG sources, keeping `analyzeduration=0`, so PyAV returns after enough bytes to identify the stream.

## Why

Observed on a Bambu Lab A1 in hub mode:

- Bambu printer registration succeeds.
- MQTT state is read successfully.
- Port `6000` is reachable from inside the container.
- `BambuJpegStream._next_jpeg()` returns a complete valid JPEG frame.
- `av.open(stream, format="mjpeg", options={"analyzeduration": "0"})` keeps reading frames and does not return promptly.
- Camera refresh therefore leaves `cameras=[]`.

With `probesize=32`, the same stream opens and decodes a frame.

## Implementation

- Adds `MJPEG_LIVE_OPTIONS = {"analyzeduration": "0", "probesize": "32"}` next to the other server-platform constants.
- Uses those options only for callable MJPEG live sources, which covers bespoke sources such as the Bambu A1/P1 chamber camera path.
- Adds an inline comment explaining why the probe is intentionally short.
- Adds unit coverage that verifies callable MJPEG sources pass both `analyzeduration=0` and `probesize=32` to PyAV.

## Verification

Added unit coverage for callable MJPEG sources passing the live-stream PyAV options.

Ran targeted tests:

```bash
uv run --frozen --dev pytest tests/test_api.py::test_bambu_jpeg_stream_strips_frame_headers tests/test_server_platform.py -q
```

Result: `2 passed`.

Also verified against a real Bambu A1 using a locally built Docker image:

- Printer camera refresh registered `Chamber camera`.
- Camera source kind: `bambu`.
- Camera online: `true`.
- API frame endpoint returned a valid `1536x1080` JPEG.

## Notes

This only changes the probing options for callable MJPEG sources, which are currently used for bespoke live sources such as the Bambu A1/P1 chamber camera path.
