### PR TITLE
v2.2.2 - Bambu A1/P1 camera fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ release notes.
 The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2] - 2026-06-26
+
+### Fixed
+
+- **Bambu A1, A1 mini, P1P and P1S chamber cameras now show up on the dashboard.** Adding one of
+  these printers registered the printer but not its chamber camera — PrintGuard kept probing the
+  live camera stream instead of opening it, so no camera and no video appeared. The stream now
+  opens on its first frame and the camera registers like any other. (X1- and H2-series cameras use
+  RTSP and were never affected.)
+
 ## [2.2.1] - 2026-06-25
 
 ### Changed

--- a/printguard/server/platform.py
+++ b/printguard/server/platform.py
@@ -29,6 +29,7 @@ FPS_SAMPLE_FRAMES = 25
 MEASURE_WARMUP_S = 1.0
 OPEN_WAIT_S = 8.0
 RECONNECT_DELAY_S = 3.0
+MJPEG_LIVE_OPTIONS = {"analyzeduration": "0", "probesize": "32"}
 
 
 class AVSource:
@@ -53,10 +54,15 @@ class AVSource:
         self._thread.start()
 
     def _open(self) -> tuple[Any, Any]:
-        """Opens the container, returning it and any pipe to close afterwards."""
+        """Opens the container, returning it and any pipe to close afterwards.
+
+        Callable sources are live MJPEG pipes; MJPEG_LIVE_OPTIONS caps the probe
+        so av.open identifies the stream from its first frame instead of draining
+        the pipe to fill PyAV's multi-megabyte default and never returning.
+        """
         if not isinstance(self._source, str):
             pipe = self._source()
-            return av.open(pipe, format="mjpeg", options={"analyzeduration": "0"}), pipe
+            return av.open(pipe, format="mjpeg", options=MJPEG_LIVE_OPTIONS), pipe
         options = {}
         if self._source.startswith("rtsp://"):
             options["rtsp_transport"] = "tcp"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "printguard"
-version = "2.2.1"
+version = "2.2.2"
 description = "Real-time 3D print failure detection"
 
 license = "GPL-2.0-only"

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -177,6 +177,30 @@ def test_bambu_jpeg_stream_strips_frame_headers() -> None:
     assert out == b"".join(jpegs), "the 16-byte frame headers are stripped, leaving concatenated JPEGs"
 
 
+def test_callable_mjpeg_sources_cap_pyav_probe(monkeypatch) -> None:
+    from printguard.server import platform
+
+    pipe = object()
+    captured = {}
+
+    def fake_open(target, *, format, options):
+        captured.update(target=target, format=format, options=options)
+        return "container"
+
+    monkeypatch.setattr(platform.av, "open", fake_open)
+    source = object.__new__(platform.AVSource)
+    source._source = lambda: pipe
+
+    container, returned_pipe = source._open()
+
+    assert (container, returned_pipe) == ("container", pipe)
+    assert captured == {
+        "target": pipe,
+        "format": "mjpeg",
+        "options": {"analyzeduration": "0", "probesize": "32"},
+    }, "live MJPEG pipes cap PyAV probing so av.open returns instead of draining frames"
+
+
 async def test_unknown_ids_and_events() -> None:
     async with api() as (client, _engine, _platform, _monitor_id, _printer_id, _camera_id, _tokens):
         assert (await client.get("/printers/nope")).status_code == 404

--- a/uv.lock
+++ b/uv.lock
@@ -878,7 +878,7 @@ wheels = [
 
 [[package]]
 name = "printguard"
-version = "2.2.1"
+version = "2.2.2"
 source = { editable = "." }
 dependencies = [
     { name = "ai-edge-litert" },


### PR DESCRIPTION
Bambu A1, A1 mini, P1P and P1S stream their chamber camera as JPEG over a proprietary port-6000 pipe (no RTSP). PrintGuard decodes it with PyAV/FFmpeg, but on a live pipe `av.open()` kept reading frames to fill FFmpeg's default multi-MB `probesize` before `find_stream_info` returned — so the printer registered while its camera never did (`cameras=[]`, no error, no video on the dashboard).

- Cap the probe for callable live-MJPEG sources (`probesize=32`, FFmpeg's minimum, alongside `analyzeduration=0`) so `av.open` identifies the stream from its first frame. X1-/H2-series RTSP cameras take the string-URL path and are unaffected.
- Unit coverage pinning the PyAV options passed for callable MJPEG sources.

Thanks to @lu15gv for the report and fix (#70).
