### PR TITLE
Document + type the camera/monitor read surface (response bodies + OpenAPI models)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ release notes.
 The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.3] - 2026-07-06
+
+### Added
+
+- **The `/api/v1` read endpoints now describe their response bodies.** `docs/api.md` documents
+  the camera and monitor object shapes — and, importantly, where a camera's failure signal lives:
+  `last_result.prediction`, since the smoothed 0–1 defect score is a per-monitor quantity, not a
+  field on the camera. The camera and monitor routes also carry Pydantic response models, so the
+  interactive `/api/v1/docs` shows the shapes instead of empty bodies. The models are additive
+  only (every field optional, extras pass straight through), so responses are unchanged.
+
 ## [2.2.2] - 2026-06-26
 
 ### Fixed

--- a/docs/api.md
+++ b/docs/api.md
@@ -140,3 +140,65 @@ shape, so a printer reads and controls the same way regardless of its service.
 - **State** — `{ "status", "progress" (0–100), "job" }`, reported on printer objects as
   `device_state`.
 - **Actions** — `pause`, `resume`, `cancel`.
+
+## Reading detection state
+
+The response bodies below are what an integrator polls to answer "is this print failing?".
+Two facts matter and are easy to miss: the **camera** carries a per-frame *classification*,
+while the smoothed **0–1 defect score** is a per-**monitor** quantity — the camera object has
+no numeric score field.
+
+**Camera object** (`GET /cameras`, `GET /cameras/{id}`):
+
+```jsonc
+{
+  "id": "cam_1a2b",
+  "name": "Left printer",
+  "source": { /* redacted of any access_code / credentials */ },
+  "printer_id": "prn_…" | null,
+  "max_fps": 5.0, "target_fps": 2.0, "achieved_fps": 1.9,   // rate
+  "inferring": true, "in_use": true, "online": true,        // health
+  "last_result": {                                          // latest score (per FRAME)
+    "prediction": "success",                                //   "success" | "failure" | "unknown"
+    "distances": { "success": 0.48, "failure": 1.64 },      //   distance to each class prototype
+    "margin": 1.16                                          //   runner-up minus best (confidence)
+  },
+  "brightness": 1.0, "contrast": 1.0, "sharpness": 0.0, "crop": null, "rotation": 0
+}
+```
+
+`last_result` is the newest raw classification, or `null` before the camera has been
+inferred. `prediction` is simply the **nearest class prototype** for that frame (no
+threshold applied) — the quickest per-camera "failing?" read. It is `"unknown"` when the
+frame can't be classified (e.g. the embedding isn't finite).
+
+**Monitor object** (`GET /monitors`, `GET /monitors/{id}`): binds a camera (+ optional
+printer) and holds the detection policy and the latest alert:
+
+```jsonc
+{
+  "id": "mon_…",
+  "camera_id": "cam_1a2b",
+  "printer_id": "prn_…" | "",
+  "sensitivity": 1.0,          // scales how far the distance margin moves the score off 0.5
+  "threshold": 0.6,            // defect score at/above which a frame counts as a failure
+  "watching": true,            // whether it is actively inferring right now
+  "alert": {                   // null until a sustained defect trips the watchdog
+    "score": 0.82, "action": "pause", "ts": 1720000000.0
+  }
+}
+```
+
+**Prediction vs defect score.** The **0–1 defect score** (`0.5` = decision boundary, higher
+= more defective) applies a monitor's `sensitivity` to the frame's distance margin, so it is
+**per-monitor, not on the camera**. It appears in:
+
+- the `result` events on the WebSocket and `GET /events`:
+  `{ "event": "result", "monitor_id", "camera_id", "score" (0–1), "prediction" (this
+  monitor's `threshold` applied), "margin", "ms", "ts" }`,
+- a monitor's `alert.score` once it trips, and
+- the MQTT *Defect score* sensor, published as `0–100` (the `0–1` score ×100).
+
+So: to poll one camera's current verdict, read `GET /cameras/{id}` → `last_result.prediction`;
+for the smoothed `0–1` score or a monitor's threshold-applied verdict, read the monitor or the
+`result` events.

--- a/printguard/server/api.py
+++ b/printguard/server/api.py
@@ -14,7 +14,7 @@ from urllib.parse import urlsplit, urlunsplit
 
 from fastapi import Depends, FastAPI, HTTPException, Request, Response
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict
 
 from ..engine.engine import Engine
 from ..engine.integrations import INTEGRATIONS
@@ -130,6 +130,80 @@ class ActionBody(BaseModel):
     action: Literal["pause", "resume", "cancel"]
 
 
+# ── Read-surface response models ───────────────────────────────────────────────
+# These document the shapes the read endpoints return so /api/v1/docs is
+# self-describing. They are permissive by design: every field is optional and
+# `extra="allow"` passes any field not listed here straight through — so adding a
+# field to a resource never needs a model change and nothing is ever stripped or
+# rejected. Serialisation is still driven by each resource's `.public()`.
+
+
+class LastResult(BaseModel):
+    """The newest raw classification for a camera frame. Nearest class prototype,
+    per-class distances, and the runner-up-minus-best margin. No threshold is
+    applied here — this is the model's raw verdict, not a monitor's decision."""
+
+    prediction: Literal["success", "failure", "unknown"] | None = None
+    distances: dict[str, float] | None = None
+    margin: float | None = None
+    model_config = ConfigDict(extra="allow")
+
+
+class CameraOut(BaseModel):
+    """A registered camera with live stats. The failure signal is the per-frame
+    `last_result.prediction`; there is no numeric score field on a camera (the
+    0–1 defect score is per-monitor — see MonitorOut and the `result` events)."""
+
+    id: str
+    name: str | None = None
+    source: dict[str, Any] | None = None
+    printer_id: str | None = None
+    max_fps: float | None = None
+    target_fps: float | None = None
+    achieved_fps: float | None = None
+    inferring: bool | None = None
+    in_use: bool | None = None
+    online: bool | None = None
+    last_result: LastResult | None = None
+    brightness: float | None = None
+    contrast: float | None = None
+    sharpness: float | None = None
+    crop: dict[str, float] | None = None
+    rotation: int | None = None
+    model_config = ConfigDict(extra="allow")
+
+
+class MonitorAlert(BaseModel):
+    """The latest tripped alert for a monitor; null until a sustained defect
+    crosses the monitor's threshold. `score` is the 0–1 defect score."""
+
+    score: float | None = None
+    action: str | None = None
+    ts: float | None = None
+    model_config = ConfigDict(extra="allow")
+
+
+class MonitorOut(BaseModel):
+    """A monitor binds a camera (+ optional printer) and holds the detection
+    policy. `threshold` is the 0–1 defect score at/above which a frame counts as
+    a failure; `sensitivity` scales the score off the 0.5 boundary."""
+
+    id: str
+    name: str | None = None
+    camera_id: str | None = None
+    printer_id: str | None = None
+    enabled: bool | None = None
+    threshold: float | None = None
+    sensitivity: float | None = None
+    consecutive: int | None = None
+    notify: bool | None = None
+    on_defect: str | None = None
+    cooldown_s: int | None = None
+    watching: bool | None = None
+    alert: MonitorAlert | None = None
+    model_config = ConfigDict(extra="allow")
+
+
 def _find(items: list[dict[str, Any]], item_id: str, kind: str) -> dict[str, Any]:
     for item in items:
         if item["id"] == item_id:
@@ -215,29 +289,29 @@ def build_api_app(auth: ApiAuth) -> FastAPI:
         """Returns the full snapshot: cameras, printers, monitors, settings and stats."""
         return public_state(engine)
 
-    @api.get("/monitors", operation_id="list_monitors", tags=["read"])
+    @api.get("/monitors", operation_id="list_monitors", tags=["read"], response_model=list[MonitorOut])
     async def list_monitors(engine: Engine = Depends(get_engine)) -> list[dict[str, Any]]:
         """Lists every monitor with its camera, linked printer and latest alert."""
         return public_state(engine)["monitors"]
 
-    @api.get("/monitors/{monitor_id}", operation_id="get_monitor", tags=["read"])
+    @api.get("/monitors/{monitor_id}", operation_id="get_monitor", tags=["read"], response_model=MonitorOut)
     async def get_monitor(monitor_id: str, engine: Engine = Depends(get_engine)) -> dict[str, Any]:
         """Returns one monitor's settings, bindings and latest alert."""
         return _find(public_state(engine)["monitors"], monitor_id, "monitor")
 
-    @api.post("/monitors", operation_id="add_monitor", tags=["manage"])
+    @api.post("/monitors", operation_id="add_monitor", tags=["manage"], response_model=list[MonitorOut])
     async def add_monitor(body: MonitorFields, engine: Engine = Depends(get_engine)) -> list[dict[str, Any]]:
         """Creates a monitor binding a camera and an optional printer."""
         await engine.request({"cmd": "monitor.add", "monitor": body.model_dump(exclude_none=True)})
         return public_state(engine)["monitors"]
 
-    @api.patch("/monitors/{monitor_id}", operation_id="update_monitor", tags=["manage"])
+    @api.patch("/monitors/{monitor_id}", operation_id="update_monitor", tags=["manage"], response_model=MonitorOut)
     async def update_monitor(monitor_id: str, body: MonitorFields, engine: Engine = Depends(get_engine)) -> dict[str, Any]:
         """Updates a monitor's bindings, thresholds or defect response."""
         await engine.request({"cmd": "monitor.update", "id": monitor_id, "patch": body.model_dump(exclude_none=True)})
         return _find(public_state(engine)["monitors"], monitor_id, "monitor")
 
-    @api.delete("/monitors/{monitor_id}", operation_id="remove_monitor", tags=["manage"])
+    @api.delete("/monitors/{monitor_id}", operation_id="remove_monitor", tags=["manage"], response_model=list[MonitorOut])
     async def remove_monitor(monitor_id: str, engine: Engine = Depends(get_engine)) -> list[dict[str, Any]]:
         """Removes a monitor and returns the updated monitor list."""
         await engine.request({"cmd": "monitor.remove", "id": monitor_id})
@@ -284,12 +358,12 @@ def build_api_app(auth: ApiAuth) -> FastAPI:
         events = await engine.request({"cmd": "printer.test", "provider": body.provider, "config": body.config})
         return next((e for e in events if e.get("event") == "printer_test"), {"ok": False})
 
-    @api.get("/cameras", operation_id="list_cameras", tags=["read"])
+    @api.get("/cameras", operation_id="list_cameras", tags=["read"], response_model=list[CameraOut])
     async def list_cameras(engine: Engine = Depends(get_engine)) -> list[dict[str, Any]]:
         """Lists every camera with its rate, health and latest score."""
         return public_state(engine)["cameras"]
 
-    @api.get("/cameras/{camera_id}", operation_id="get_camera", tags=["read"])
+    @api.get("/cameras/{camera_id}", operation_id="get_camera", tags=["read"], response_model=CameraOut)
     async def get_camera(camera_id: str, engine: Engine = Depends(get_engine)) -> dict[str, Any]:
         """Returns one camera's settings and live statistics."""
         return _find(public_state(engine)["cameras"], camera_id, "camera")
@@ -308,7 +382,7 @@ def build_api_app(auth: ApiAuth) -> FastAPI:
             raise HTTPException(404, f"no frame available for camera {camera_id!r}")
         return Response(jpeg, media_type="image/jpeg")
 
-    @api.post("/cameras", operation_id="add_camera", tags=["manage"])
+    @api.post("/cameras", operation_id="add_camera", tags=["manage"], response_model=list[CameraOut])
     async def add_camera(body: CameraCreate, engine: Engine = Depends(get_engine)) -> list[dict[str, Any]]:
         """Registers a camera and returns the updated camera list."""
         payload = {"cmd": "camera.add", "source": body.source.model_dump(exclude_none=True)}
@@ -317,13 +391,13 @@ def build_api_app(auth: ApiAuth) -> FastAPI:
         await engine.request(payload)
         return public_state(engine)["cameras"]
 
-    @api.patch("/cameras/{camera_id}", operation_id="update_camera", tags=["manage"])
+    @api.patch("/cameras/{camera_id}", operation_id="update_camera", tags=["manage"], response_model=CameraOut)
     async def update_camera(camera_id: str, body: CameraPatch, engine: Engine = Depends(get_engine)) -> dict[str, Any]:
         """Updates a camera's name or image adjustments."""
         await engine.request({"cmd": "camera.update", "id": camera_id, "patch": body.model_dump(exclude_none=True)})
         return _find(public_state(engine)["cameras"], camera_id, "camera")
 
-    @api.delete("/cameras/{camera_id}", operation_id="remove_camera", tags=["manage"])
+    @api.delete("/cameras/{camera_id}", operation_id="remove_camera", tags=["manage"], response_model=list[CameraOut])
     async def remove_camera(camera_id: str, engine: Engine = Depends(get_engine)) -> list[dict[str, Any]]:
         """Removes a camera and returns the updated camera list."""
         await engine.request({"cmd": "camera.remove", "id": camera_id})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "printguard"
-version = "2.2.2"
+version = "2.2.3"
 description = "Real-time 3D print failure detection"
 
 license = "GPL-2.0-only"

--- a/uv.lock
+++ b/uv.lock
@@ -878,7 +878,7 @@ wheels = [
 
 [[package]]
 name = "printguard"
-version = "2.2.2"
+version = "2.2.3"
 source = { editable = "." }
 dependencies = [
     { name = "ai-edge-litert" },


### PR DESCRIPTION
Hi guys, 
Thanks for making this.   I was working on implementing this and my AI struggled with the full spec as described in the api docs.  I had to stand up a live instance for it to fully figure out the exact details.   What follows is the AI description:


## What

The REST reference lists the read endpoints but not their **response bodies**, and the camera/monitor endpoints return bare `dict[str, Any]` so `/api/v1/docs` shows no response schema. Integrating an external tool that polls PrintGuard's per-camera verdict, I couldn't tell what `GET /cameras/{id}` returns without reading the engine source — and the docs wording ("cameras with rate, health and latest score") made it natural to assume the camera exposes a numeric score. It doesn't.

Two changes make the read surface self-describing:

1. **docs/api.md** — a new *Reading detection state* section documenting the **camera** and **monitor** object shapes, and one easy-to-miss distinction: the camera carries a per-frame *classification* (`last_result.prediction` / `distances` / `margin`), while the smoothed **0-1 defect score** is a per-*monitor* quantity (it appears in `result`/`alert` events and the MQTT sensor as x100) — there is no numeric score field on the camera.

2. **printguard/server/api.py** — typed the camera + monitor GET/POST/PATCH/DELETE endpoints with Pydantic response models (`CameraOut`, `MonitorOut`, nested `LastResult` / `MonitorAlert`), so `/api/v1/docs` now shows the shapes instead of empty bodies.

## Why it's safe

The response models are **additive-only**: every field is optional and `extra="allow"` passes any unlisted field straight through, so nothing is stripped from responses or can fail validation, and adding a field to a resource needs no model change. Serialisation is still driven by each resource's `.public()`.

## Verification

- Field-passthrough verified on pydantic v2 against full camera/monitor payloads (including an unknown field) — every field survives the round-trip; nested `last_result`/`alert` + null validated.
- `python -m py_compile` clean.
- Shapes cross-checked against `main`: `Camera.public()` (registry.py), the `result` event (engine.py), `alert` (watchdog.py), `defect_score` (vision.py).
- I did **not** run the full `uv run pytest` locally (needs the model + mediamtx); the change is behavior-preserving by construction (docs + OpenAPI schema only).

Docs-and-schema only; no runtime behavior change.
