### PR TITLE
feat(api): POST /api/v1/classify — score a supplied JPEG frame

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ release notes.
 The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.0] - 2026-07-06
+
+### Added
+
+- **`POST /api/v1/classify` — score a single supplied JPEG frame.** Hand the model a frame
+  directly (POST the bytes as `image/jpeg`, `read` scope) and get back
+  `{prediction, distances, margin, defect_score}` — the same verdict the scheduler produces for
+  a registered camera, without registering one. Useful for an external orchestrator that can
+  reach a camera PrintGuard can't (e.g. a cloud tool tunnelling to a LAN printer), or an
+  agent/CI wanting a one-off check. Reuses the engine's own inference; hub only.
+
 ## [2.2.2] - 2026-06-26
 
 ### Fixed

--- a/docs/api.md
+++ b/docs/api.md
@@ -56,6 +56,7 @@ Base path `/api/v1`. Requests and responses are JSON, except the camera frame, w
 | `GET` | `/cameras` | read | List cameras with rate, health and latest score |
 | `GET` | `/cameras/{id}` | read | One camera |
 | `GET` | `/cameras/{id}/frame` | read | Freshest frame as `image/jpeg` |
+| `POST` | `/classify` | read | Classify a supplied JPEG frame (body = `image/jpeg`); no registered camera needed |
 | `GET` | `/events` | read | Recent alerts, warnings, device changes and errors |
 | `POST` | `/printers/{id}/action` | control | `{"action": "pause" \| "resume" \| "cancel"}` |
 | `POST` | `/monitors` | manage | Add a monitor (binds a camera + optional printer) |
@@ -85,6 +86,11 @@ curl -H "Authorization: Bearer $TOKEN" https://host/api/v1/cameras/$CAM/frame -o
 # Pause a print
 curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: application/json" \
   -d '{"action":"pause"}' https://host/api/v1/printers/$PRINTER/action
+
+# Classify a supplied frame (no registered camera needed)
+curl -X POST -H "Authorization: Bearer $TOKEN" -H "Content-Type: image/jpeg" \
+  --data-binary @frame.jpg https://host/api/v1/classify
+# → {"prediction":"success","distances":{...},"margin":1.16,"defect_score":0.35}
 ```
 
 ## MCP server

--- a/printguard/server/api.py
+++ b/printguard/server/api.py
@@ -9,13 +9,16 @@ the same tags drive both this API's bearer-scope guard and the MCP tool filter.
 from __future__ import annotations
 
 import hmac
+import io
 from typing import Any, Literal
 from urllib.parse import urlsplit, urlunsplit
 
+import av
 from fastapi import Depends, FastAPI, HTTPException, Request, Response
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 
+from ..engine import vision
 from ..engine.engine import Engine
 from ..engine.integrations import INTEGRATIONS
 from ..engine.notifiers import NOTIFIERS
@@ -307,6 +310,28 @@ def build_api_app(auth: ApiAuth) -> FastAPI:
         if jpeg is None:
             raise HTTPException(404, f"no frame available for camera {camera_id!r}")
         return Response(jpeg, media_type="image/jpeg")
+
+    @api.post("/classify", operation_id="classify_frame", tags=["read"])
+    async def classify_frame(
+        request: Request, sensitivity: float = 1.0, engine: Engine = Depends(get_engine)
+    ) -> dict[str, Any]:
+        """Classify a single supplied JPEG frame — no registered camera needed.
+
+        For an external orchestrator that can reach a camera PrintGuard cannot
+        (e.g. a cloud tool tunnelling to a LAN printer): POST the frame bytes as
+        `image/jpeg` and get back the same classification the scheduler produces
+        for a registered camera, plus the 0–1 `defect_score` for the given
+        `sensitivity`. Reuses the engine's own inference (`Platform.infer`) and
+        the hub's PyAV to decode — REST is hub-only, so there's no browser path.
+        """
+        data = await request.body()
+        try:
+            with av.open(io.BytesIO(data)) as container:
+                rgb = next(container.decode(video=0)).to_ndarray(format="rgb24")
+        except Exception as exc:
+            raise HTTPException(400, f"could not decode image: {exc}")
+        result = await engine.platform.infer(rgb)
+        return {**result, "defect_score": vision.defect_score(result, sensitivity)}
 
     @api.post("/cameras", operation_id="add_camera", tags=["manage"])
     async def add_camera(body: CameraCreate, engine: Engine = Depends(get_engine)) -> list[dict[str, Any]]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "printguard"
-version = "2.2.2"
+version = "2.3.0"
 description = "Real-time 3D print failure detection"
 
 license = "GPL-2.0-only"

--- a/uv.lock
+++ b/uv.lock
@@ -878,7 +878,7 @@ wheels = [
 
 [[package]]
 name = "printguard"
-version = "2.2.2"
+version = "2.3.0"
 source = { editable = "." }
 dependencies = [
     { name = "ai-edge-litert" },


### PR DESCRIPTION
Companion PR to #78 (the `frame.classify` proposal). Opening the code alongside the discussion — happy to hold, reshape, or close if you'd rather settle the design in #78 first.

## What

Adds `POST /api/v1/classify` (`read` scope): POST a JPEG body, get back the same classification the scheduler produces for a registered camera —

```json
{ "prediction": "success | failure | unknown",
  "distances": { "success": 0.48, "failure": 1.64 },
  "margin": 1.16,
  "defect_score": 0.35 }
```

`defect_score` (0-1) is included for a `?sensitivity=` query param (default 1.0), matching `vision.defect_score`.

## Why

For an external orchestrator that can reach a camera PrintGuard cannot — a cloud tool tunnelling to a LAN printer, or an agent/CI wanting a one-off verdict on a still without registering a camera + monitor. Today classification only happens for cameras PrintGuard pulls itself (`GET /cameras/{id}` -> `last_result`), so there's no way to hand it a frame you already hold.

## How

- Reuses the engine's own inference (`Platform.infer(rgb)` -> `vision.classify`) — no new inference path.
- Decodes the body with the hub's PyAV (`av.open(io.BytesIO(...))`), the same reader the camera path uses.
- REST is hub-only, so there's no browser / Platform-contract change.

~15 lines in `server/api.py`, plus a docs row + curl example in `docs/api.md`.

## On the architecture principle

I read `docs/architecture.md` and I know the programmatic surface is meant to be a thin transport of UI commands; this route does a little work (decode) in the transport. If you'd prefer it fully protocol-shaped, I'm glad to make it a real engine command (`frame.classify`) with a small dashboard "test an image" affordance that uses it (also handy for threshold/sensitivity tuning) — just say which you'd rather.

## Verification

Validated against a live 2.2.2: `av.open(BytesIO(jpeg))` decode -> `Platform.infer` returns the identical `{prediction, distances, margin}` to the camera path on a real print frame. `python -m py_compile` clean. (Did not run the full `uv run pytest` locally — needs mediamtx; this adds one read-only route and no engine changes.)
