### PR TITLE
v2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 
 ## [2.3.1] - 2026-07-10
 
+### Changed
+
+- **The macOS app installs like a normal Mac app.** The download now presents PrintGuard beside
+  your Applications folder to drag it into, instead of a lone app icon. The builds are still
+  unsigned for now, so the first launch needs one manual approval — and on macOS Sequoia that moved
+  from the old right-click → **Open** to **System Settings → Privacy & Security → Open Anyway**
+  (double-click the app once, then approve it there).
+
 ### Security
 
 - **API token secrets stay out of the hub's logs.** Generating a token under **Settings → API &

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ release notes.
 The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1] - 2026-07-10
+
+### Security
+
+- **API token secrets stay out of the hub's logs.** Generating a token under **Settings → API &
+  MCP access** now hands its one-time secret to the dashboard without that secret ever passing
+  through the server's log writer, resolving a code-scanning finding about clear-text logging of
+  sensitive data. The token is still shown once and only its hash is stored — nothing about your
+  existing tokens changes.
+
 ## [2.3.0] - 2026-07-03
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -76,8 +76,9 @@ network at `http://<computer>:8000`. Nothing leaves your machine.
 </div>
 
 Turn on **Start at login** from the tray menu and forget about it. The builds are unsigned for now,
-so the first launch needs a right-click → **Open** on macOS, or **More info → Run anyway** on
-Windows. On Linux, run the [Docker hub](#docker--for-an-always-on-server-or-nas) instead.
+so the first launch needs one manual approval: on macOS, double-click the app, then open
+**System Settings → Privacy & Security** and click **Open Anyway** under *Security*; on Windows,
+choose **More info → Run anyway**. On Linux, run the [Docker hub](#docker--for-an-always-on-server-or-nas) instead.
 
 ### Docker — for an always-on server or NAS
 

--- a/packaging/build.sh
+++ b/packaging/build.sh
@@ -49,7 +49,18 @@ uv run --extra desktop pyinstaller packaging/printguard.spec --noconfirm --distp
 
 if [ "$OS" = darwin ]; then
   out="dist/PrintGuard-${LABEL}.dmg"
-  hdiutil create -volname PrintGuard -srcfolder dist/PrintGuard.app -ov -format UDZO "$out" >/dev/null
+  command -v create-dmg >/dev/null || HOMEBREW_NO_AUTO_UPDATE=1 brew install create-dmg
+  staging="build/desktop/dmg"; rm -rf "$staging"; mkdir -p "$staging"
+  cp -R dist/PrintGuard.app "$staging/"
+  create-dmg \
+    --volname PrintGuard \
+    --volicon build/desktop/icon.icns \
+    --window-size 600 400 \
+    --icon-size 128 \
+    --icon PrintGuard.app 160 185 \
+    --app-drop-link 440 185 \
+    --hide-extension PrintGuard.app \
+    "$out" "$staging"
 else
   out="dist/PrintGuard-${LABEL}.zip"
   powershell -NoProfile -Command "Compress-Archive -Path dist/PrintGuard -DestinationPath '$out' -Force"

--- a/printguard/engine/engine.py
+++ b/printguard/engine/engine.py
@@ -151,7 +151,7 @@ class Engine:
             self._sinks.remove(sink)
 
     def emit(self, event: dict[str, Any]) -> None:
-        """Broadcasts an event to every connected transport.
+        """Logs the event when loggable, then broadcasts it to every transport.
 
         Alert, warning, error and device events are also written to the log,
         so the log tail carries the same timeline a maintainer sees in a bug
@@ -160,6 +160,15 @@ class Engine:
         level = EVENT_LOG_LEVELS.get(event.get("event", ""))
         if level is not None:
             logger.log(level, "%s %s", event["event"], {k: v for k, v in event.items() if k not in ("event", "req_id")})
+        self._broadcast(event)
+
+    def _broadcast(self, event: dict[str, Any]) -> None:
+        """Delivers an event to recent history and every transport sink.
+
+        Kept separate from emit() so an event carrying a one-time secret
+        (token_created) can reach the requesting transport without ever being
+        written to the log in clear text.
+        """
         if event.get("event") in RECENT_EVENT_TYPES:
             self._recent.append(event)
         for sink in list(self._sinks):
@@ -581,7 +590,7 @@ class Engine:
         record, secret = new_token(name, message.get("scope") or "read")
         token = Token(**record)
         self.tokens.add(token)
-        self.emit({"event": "token_created", **token.public(), "token": secret, "req_id": message.get("req_id")})
+        self._broadcast({"event": "token_created", **token.public(), "token": secret, "req_id": message.get("req_id")})
 
     async def _cmd_token_remove(self, message: dict[str, Any]) -> None:
         self.tokens.remove(message["id"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "printguard"
-version = "2.3.0"
+version = "2.3.1"
 description = "Real-time 3D print failure detection"
 
 license = "GPL-2.0-only"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -14,7 +14,7 @@ import numpy as np
 from fakes import FakePlatform
 
 from printguard.engine import logs, reports, vision, watchdog
-from printguard.engine.engine import Engine
+from printguard.engine.engine import EVENT_LOG_LEVELS, Engine
 from printguard.engine.integrations import INTEGRATIONS
 
 OCTOPRINT = {"provider": "octoprint", "config": {"base_url": "http://op", "api_key": "k"}}
@@ -459,3 +459,17 @@ async def test_report_send_surfaces_failure() -> None:
     assert [e["ok"] for e in sent] == [False, False]
     assert "description" in sent[0]["error"]
     assert "429" in sent[1]["error"]
+
+
+async def test_token_secret_reaches_requester_but_is_never_logged(monkeypatch) -> None:
+    monkeypatch.setitem(EVENT_LOG_LEVELS, "token_created", logging.ERROR)
+    platform = FakePlatform(infer_s=0.02)
+    async with configured_logging(), running_engine(platform, camera_fps=[]) as (engine, events):
+        await engine.handle({"cmd": "token.create", "req_id": 7, "name": "ci", "scope": "control"})
+
+    created = next(e for e in events if e.get("event") == "token_created")
+    assert created["req_id"] == 7 and created["scope"] == "control"
+    assert engine.tokens.get(created["id"]) is not None, "token was not registered"
+    secret = created["token"]
+    assert secret.startswith("pg_"), "requester did not receive the one-time secret"
+    assert all(secret not in line for line in logs.recent()), "token secret leaked into the log tail"

--- a/uv.lock
+++ b/uv.lock
@@ -1062,7 +1062,7 @@ wheels = [
 
 [[package]]
 name = "printguard"
-version = "2.3.0"
+version = "2.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "ai-edge-litert" },


### PR DESCRIPTION
Release PR: **v2.3.1** → `main`. Merging ships the release — the `[2.3.1]` section of `CHANGELOG.md` is published verbatim as the GitHub release notes.

### Changed
- **The macOS app installs like a normal Mac app.** The download now presents PrintGuard beside your Applications folder to drag it into, instead of a lone app icon. Builds are still unsigned for now, so the first launch needs one manual approval — on macOS Sequoia that moved from right-click → **Open** to **System Settings → Privacy & Security → Open Anyway**.

### Security
- **API token secrets stay out of the hub's logs.** Generating a token under **Settings → API & MCP access** now hands its one-time secret to the dashboard without it ever passing through the server's log writer, resolving a code-scanning finding about clear-text logging of sensitive data. The token is still shown once and only its hash is stored.

Gated on the three required checks: tests, production image build, and version (2.3.1 with a matching changelog section).
