### PR TITLE
v2.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ release notes.
 The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.2] - 2026-07-10
+
+### Fixed
+
+- **Landing-page macOS install steps match current macOS.** The desktop-app panel on the
+  [project site](https://oliverbravery.github.io/PrintGuard/) now shows the macOS Sequoia unlock
+  path — **System Settings → Privacy & Security → Open Anyway** — in place of the old
+  right-click → **Open** that newer macOS no longer offers. Website copy only; the app and Docker
+  image are unchanged.
+
 ## [2.3.1] - 2026-07-10
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "printguard"
-version = "2.3.1"
+version = "2.3.2"
 description = "Real-time 3D print failure detection"
 
 license = "GPL-2.0-only"

--- a/uv.lock
+++ b/uv.lock
@@ -1062,7 +1062,7 @@ wheels = [
 
 [[package]]
 name = "printguard"
-version = "2.3.1"
+version = "2.3.2"
 source = { editable = "." }
 dependencies = [
     { name = "ai-edge-litert" },

--- a/web/src/components/Home.tsx
+++ b/web/src/components/Home.tsx
@@ -218,8 +218,10 @@ export function Home() {
               )}
             </div>
             <p className="mt-4 text-xs leading-relaxed text-text-2">
-              Unsigned for now — first launch needs a right-click → <span className="text-text-1">Open</span> on macOS, or
-              <span className="text-text-1"> More info → Run anyway</span> on Windows.
+              Unsigned for now — first launch needs a one-time approval. On macOS, open{" "}
+              <span className="text-text-1">System Settings → Privacy &amp; Security</span> and click{" "}
+              <span className="text-text-1">Open Anyway</span>. On Windows, choose{" "}
+              <span className="text-text-1">More info → Run anyway</span>.
             </p>
           </div>
 


### PR DESCRIPTION
Release PR: **v2.3.2** → `main`. The `[2.3.2]` section of `CHANGELOG.md` publishes verbatim as the GitHub release notes.

### Fixed
- **Landing-page macOS install steps match current macOS.** The desktop-app panel on the [project site](https://oliverbravery.github.io/PrintGuard/) now shows the macOS Sequoia unlock path — **System Settings → Privacy & Security → Open Anyway** — instead of the old right-click → **Open** that newer macOS no longer offers. Website copy only; the app and Docker image are unchanged.

Gated on the three required checks: tests, production image build, and version (2.3.2 with a matching changelog section).
