### PR TITLE
v2.3.6: Idle camera capture

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -1,0 +1,21 @@
+name: Issue triage
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  label:
+    name: label
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - run: >-
+          gh issue edit "$ISSUE_NUMBER" --repo "$GITHUB_REPOSITORY" --add-label "status: needs triage"
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -155,3 +155,37 @@ jobs:
           path: web/dist
       - id: deployment
         uses: actions/deploy-pages@v4
+
+  follow-up:
+    name: reporter follow-up
+    needs: [version, docker, release, desktop, pages]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: read
+    steps:
+      - name: Ask related reporters to verify
+        env:
+          GH_TOKEN: ${{ github.token }}
+          VERSION: v${{ needs.version.outputs.version }}
+        run: |
+          pr_number=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" --jq 'map(select(.merged_at != null))[0].number // empty')
+          if [ -z "$pr_number" ]; then
+            exit 0
+          fi
+          pr_body=$(gh pr view "$pr_number" --repo "$GITHUB_REPOSITORY" --json body --jq .body)
+          issue_numbers=$(printf '%s\n' "$pr_body" | awk 'tolower($0) ~ /^[[:space:]]*relates to /' | grep -oE '#[0-9]+' | tr -d '#' || true)
+          for issue_number in $issue_numbers; do
+            marker="<!-- release-follow-up:${VERSION} -->"
+            if gh api --paginate "repos/${GITHUB_REPOSITORY}/issues/${issue_number}/comments" --jq '.[].body' | grep -Fq "$marker"; then
+              continue
+            fi
+            labels=$(gh issue view "$issue_number" --repo "$GITHUB_REPOSITORY" --json labels --jq '.labels[].name')
+            if printf '%s\n' "$labels" | grep -Fxq "status: built"; then
+              gh issue edit "$issue_number" --repo "$GITHUB_REPOSITORY" --remove-label "status: built"
+            fi
+            gh issue edit "$issue_number" --repo "$GITHUB_REPOSITORY" --add-label "status: completed"
+            message="${marker}"$'\n\n'"${VERSION} is now live. Please update PrintGuard and let me know whether it resolves this issue. If it does, you can close the issue. Otherwise, leave it open and share any remaining details so I can follow up."
+            gh issue comment "$issue_number" --repo "$GITHUB_REPOSITORY" --body "$message"
+          done

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-Coding agent guidance for PrintGuard lives in **[CLAUDE.md](CLAUDE.md)** — the single
+Coding agent guidance for PrintGuard lives in **[CLAUDE.md](CLAUDE.md)** - the single
 source of truth for commands, architecture and the project's coding conventions. Read it
 first.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ release notes.
 The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.3.6] - 2026-07-16
+## [2.3.6] - 2026-07-19
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,9 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
   of retrying the same broken session until the camera is toggled manually.
 - **Alert-only notifications now state that no printer action is configured.** This makes clear that
   detection and push alerts are still active when a printer is powered off or unreachable.
+- **Printer actions and notifications no longer pause camera inference.** Slow or unreachable
+  services are handled independently while monitoring continues, and genuinely stalled camera
+  sources are replaced automatically after a fresh-frame timeout.
 
 ## [2.3.5] - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 - **Camera and monitor status lights no longer flicker between healthy colours.** Camera indicators
   now show stable availability, while monitor indicators stay green when watching and switch red
   only for a genuine defect alert.
+- **RTSP cameras recover after a damaged stream.** If packet loss or decoder errors leave a camera
+  offline, PrintGuard now replaces the failed reader and its MediaMTX pull automatically instead
+  of retrying the same broken session until the camera is toggled manually.
 
 ## [2.3.5] - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 - **RTSP cameras recover after a damaged stream.** If packet loss or decoder errors leave a camera
   offline, PrintGuard now replaces the failed reader and its MediaMTX pull automatically instead
   of retrying the same broken session until the camera is toggled manually.
+- **Alert-only notifications now state that no printer action is configured.** This makes clear that
+  detection and push alerts are still active when a printer is powered off or unreachable.
 
 ## [2.3.5] - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 - **Desktop webcams now preview immediately after registration.** The camera stays live while its
   preview connects, then still enters standby after viewing or monitoring stops. Slow desktop
   camera startup no longer leaves orphaned captures running after the window closes.
+- **Camera and monitor status lights no longer flicker between healthy colours.** Camera indicators
+  now show stable availability, while monitor indicators stay green when watching and switch red
+  only for a genuine defect alert.
 
 ## [2.3.5] - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 
 - **Landing-page macOS install steps match current macOS.** The desktop-app panel on the
   [project site](https://oliverbravery.github.io/PrintGuard/) now shows the macOS Sequoia unlock
-  path — **System Settings → Privacy & Security → Open Anyway** — in place of the old
+  path - **System Settings → Privacy & Security → Open Anyway** - in place of the old
   right-click → **Open** that newer macOS no longer offers. Website copy only; the app and Docker
   image are unchanged.
 
@@ -93,7 +93,7 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 
 - **The macOS app installs like a normal Mac app.** The download now presents PrintGuard beside
   your Applications folder to drag it into, instead of a lone app icon. The builds are still
-  unsigned for now, so the first launch needs one manual approval — and on macOS Sequoia that moved
+  unsigned for now, so the first launch needs one manual approval - and on macOS Sequoia that moved
   from the old right-click → **Open** to **System Settings → Privacy & Security → Open Anyway**
   (double-click the app once, then approve it there).
 
@@ -102,36 +102,36 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 - **API token secrets stay out of the hub's logs.** Generating a token under **Settings → API &
   MCP access** now hands its one-time secret to the dashboard without that secret ever passing
   through the server's log writer, resolving a code-scanning finding about clear-text logging of
-  sensitive data. The token is still shown once and only its hash is stored — nothing about your
+  sensitive data. The token is still shown once and only its hash is stored - nothing about your
   existing tokens changes.
 
 ## [2.3.0] - 2026-07-03
 
 ### Added
 
-- **A desktop app for macOS and Windows — run a hub as an application.** PrintGuard now ships as a
+- **A desktop app for macOS and Windows - run a hub as an application.** PrintGuard now ships as a
   native app that runs the full hub from your menu bar / system tray. Close the window and the hub
   keeps watching, so it covers the multi-hour prints that matter; quit from the tray. The computer's
-  own webcams register straight on the hub — the app's window offers them under **Cameras →
-  This device**, and macOS asks for camera access the first time you register one — so they
+  own webcams register straight on the hub - the app's window offers them under **Cameras →
+  This device**, and macOS asks for camera access the first time you register one - so they
   keep watching with every window closed (Linux Docker hubs can still attach mapped
   `/dev/video*` devices through the API). Reach it from your phone on the same network at `http://<computer>:8000`. Detection still runs entirely on
   your own machine; no frame leaves your hardware. Turn on **Start at login** and forget about it.
   Download it from the landing page or the
-  [Releases page](https://github.com/oliverbravery/PrintGuard/releases) — the builds are unsigned for
+  [Releases page](https://github.com/oliverbravery/PrintGuard/releases) - the builds are unsigned for
   now, so the first launch needs a right-click → **Open** on macOS, or **More info → Run anyway** on
   Windows. On Linux, run the Docker hub as before. When a newer version ships, the update dialog
   offers the right download for your computer; the Docker hub keeps its pull instructions.
 
 - **Native notifications on the desktop app.** The macOS and Windows desktop app can now post
-  defect alerts to the operating system's own notification centre — with the snapshot attached —
+  defect alerts to the operating system's own notification centre - with the snapshot attached -
   so a native banner reaches you even with the window closed and no phone app set up. Turn on
   **Desktop notification** under **Settings → Alerts** (it is offered only inside the desktop app,
   next to ntfy, Telegram and Discord); on macOS, allow notifications for PrintGuard the first time
   it asks. The Docker hub, which has no desktop of its own, keeps using the push channels.
 
-- **Prusa printers now connect over PrusaLink.** Register a Prusa printer — MK4, MK4S, MK3.9,
-  MK3.5, MINI, XL, CORE One, or an MK3/MK2.5 running PrusaLink on a Raspberry Pi — alongside
+- **Prusa printers now connect over PrusaLink.** Register a Prusa printer - MK4, MK4S, MK3.9,
+  MK3.5, MINI, XL, CORE One, or an MK3/MK2.5 running PrusaLink on a Raspberry Pi - alongside
   OctoPrint, Klipper and Bambu. PrintGuard reads its job, progress and state, gates inference
   while it is idle, and can **pause or cancel** the print when a defect holds. Enable PrusaLink
   on the printer, then link it with its URL and the password shown under Settings → Network →
@@ -140,13 +140,13 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
   Prusa is offered in **hub mode only**.
 
 - **Report a bug straight from the dashboard.** Hit the ⚑ chip in the header, describe what
-  happened, attach screenshots and optionally leave an email for follow-up — anonymously, no
+  happened, attach screenshots and optionally leave an email for follow-up - anonymously, no
   account needed. Each report carries a diagnostics bundle (version, platform, configuration,
   recent errors and warnings) with **every credential stripped**, and no camera frames unless
   you attach them yourself. Nothing is ever sent unless you submit a report.
 
-- **Everything leaves a trace.** The hub now logs its whole lifecycle — boot, camera
-  attach/drop, printer actions, alerts, rejected API and socket attempts — to `docker logs`,
+- **Everything leaves a trace.** The hub now logs its whole lifecycle - boot, camera
+  attach/drop, printer actions, alerts, rejected API and socket attempts - to `docker logs`,
   and the desktop app writes a self-rotating `printguard.log` beside its data, so problems on
   a computer with no terminal can still be diagnosed. Bug reports automatically attach the
   recent engine and interface logs, scrubbed of every credential, so a report carries the
@@ -154,7 +154,7 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
   support.
 
 - **A detection history for every monitor.** Open a monitor's detail page to see its defect risk
-  charted over selectable periods, alongside a snapshot of every alert it fired — what the camera
+  charted over selectable periods, alongside a snapshot of every alert it fired - what the camera
   saw at the moment PrintGuard acted.
 
 - **Monitor settings now explain themselves.** The alert threshold, sensitivity and
@@ -162,14 +162,14 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
   it.
 
 - **The `/api/v1` read surface now describes its response bodies.** PrintGuard's API reference
-  (`docs/api.md`) documents the camera and monitor object shapes — including where a camera's
+  (`docs/api.md`) documents the camera and monitor object shapes - including where a camera's
   failure signal lives (`last_result.prediction`), since the smoothed 0–1 defect score is a
   per-monitor quantity, not a field on the camera. The camera and monitor routes now carry
   response schemas too, so the interactive `/api/v1/docs` shows the shapes instead of empty bodies.
 
-- **`POST /api/v1/classify` — score a single supplied frame.** Hand the model a frame directly
+- **`POST /api/v1/classify` - score a single supplied frame.** Hand the model a frame directly
   (POST the bytes as `image/jpeg`, `read` scope, optional `?sensitivity=`) and get back
-  `{prediction, distances, margin, defect_score}` — the same per-frame verdict the scheduler
+  `{prediction, distances, margin, defect_score}` - the same per-frame verdict the scheduler
   produces for a registered camera, without registering one. Useful for an external orchestrator
   that can reach a camera PrintGuard can't (e.g. a cloud tool tunnelling to a LAN printer), or an
   agent wanting a one-off check. Exposed both over REST and as a `classify_frame` MCP tool, so an
@@ -178,7 +178,7 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 
 ### Fixed
 
-- Registering a camera could report "no frames" even though the stream was healthy — the hub
+- Registering a camera could report "no frames" even though the stream was healthy - the hub
   gave a source eight seconds to produce a frame, which a freshly published "this device"
   camera or a slow-starting stream often exceeds. Registration now waits out a cold start
   before giving up.
@@ -188,7 +188,7 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 ### Fixed
 
 - **Bambu A1, A1 mini, P1P and P1S chamber cameras now show up on the dashboard.** Adding one of
-  these printers registered the printer but not its chamber camera — PrintGuard kept probing the
+  these printers registered the printer but not its chamber camera - PrintGuard kept probing the
   live camera stream instead of opening it, so no camera and no video appeared. The stream now
   opens on its first frame and the camera registers like any other. (X1- and H2-series cameras use
   RTSP and were never affected.)
@@ -198,21 +198,21 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 ### Changed
 
 - **One container, no second image, no terminal needed.** PrintGuard now ships as a **single
-  image** with the streaming server built in — there is no separate MediaMTX container to install
+  image** with the streaming server built in - there is no separate MediaMTX container to install
   and no specific version of it to track down (the sticking point on Unraid and similar). Install
   it with a single `docker run`, the now one-service `docker-compose.yaml`, or **one click from
-  Unraid Community Applications**. The hub still serves everything — dashboard, live video and all
-  — on `:8000`; the camera-publish ports `8554`/`1935` are optional and only matter if a camera
-  pushes a stream into PrintGuard. To put it on your network your own way — private over Tailscale,
-  public behind Cloudflare Access or an auth proxy — see the deployment guide.
+  Unraid Community Applications**. The hub still serves everything - dashboard, live video and all
+  - on `:8000`; the camera-publish ports `8554`/`1935` are optional and only matter if a camera
+  pushes a stream into PrintGuard. To put it on your network your own way - private over Tailscale,
+  public behind Cloudflare Access or an auth proxy - see the deployment guide.
 
   *Upgrading from the two-container setup?* Pull the new image and remove the `mediamtx` service
-  (and its `mediamtx.yml` mount) from your compose file — the built-in server replaces it. Your
+  (and its `mediamtx.yml` mount) from your compose file - the built-in server replaces it. Your
   `/data` volume and settings carry over untouched.
 
 - **Settings now save themselves.** Camera image adjustments (brightness, contrast, sharpness,
   rotation, crop) and monitor settings (thresholds, sensitivity, defect response, notifications)
-  now apply **live everywhere the moment you change them** — the camera preview, dashboard tiles
+  now apply **live everywhere the moment you change them** - the camera preview, dashboard tiles
   and risk gauges update as you drag, with no **Save** button to remember. A small **saved ✓**
   indicator confirms each change is stored, and anything still in flight is saved automatically
   when you close the panel. Notification channels, printers and Home Assistant (MQTT) keep an
@@ -223,40 +223,40 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 
 ### Added
 
-- **Built-in guide and a setup checklist** — a new **?** in the header opens a Guide that explains
-  every part of PrintGuard — cameras, printers, monitors, how detection and alerts work, and what
-  you can automate — each with a shortcut that jumps straight to the right place. Until your first
+- **Built-in guide and a setup checklist** - a new **?** in the header opens a Guide that explains
+  every part of PrintGuard - cameras, printers, monitors, how detection and alerts work, and what
+  you can automate - each with a shortcut that jumps straight to the right place. Until your first
   monitor is watching, the dashboard shows a **Getting started** checklist that tracks your progress
   from camera to printer to alerts to monitor, so you always know what to do next. Works the same in
   local (in-browser) mode.
-- **Light, dark and custom themes** — pick **System** (follows your device), **Light** or
+- **Light, dark and custom themes** - pick **System** (follows your device), **Light** or
   **Dark** from the new header toggle or **Settings → Appearance**, or design your own. The
-  theme editor lets you set every colour — surfaces, text, lines and the accent/ok/warn/bad
-  status colours — with a live preview as you go, and your themes are saved and synced to every
+  theme editor lets you set every colour - surfaces, text, lines and the accent/ok/warn/bad
+  status colours - with a live preview as you go, and your themes are saved and synced to every
   browser that opens the hub. The selection defaults to System, so each device follows its own
   light/dark preference until you choose one, and the correct theme paints on load with no
   flash. Works the same in local (in-browser) mode.
-- **Customisable dashboard layout** — tap **Customise** (the ▦ in the header) to arrange the
+- **Customisable dashboard layout** - tap **Customise** (the ▦ in the header) to arrange the
   dashboard around your workflow: drag monitors into any order, **pin** the ones that matter
   to the front, and **hide** the ones you don't, with a tray to bring hidden ones back. The
   camera registry can be reordered and hidden the same way. Dragging works with mouse, touch
   and keyboard, your layout is saved and synced to every browser that opens the hub, and it
   works the same in local (in-browser) mode.
-- **Home Assistant integration over MQTT** — point the hub at your MQTT broker (**Settings →
+- **Home Assistant integration over MQTT** - point the hub at your MQTT broker (**Settings →
   Home Assistant (MQTT)**) and every monitor appears in Home Assistant automatically through
   MQTT discovery, each as its own device: a **Defect** problem sensor, defect-score and state
-  sensors, the latest failure **snapshot**, an **Enabled** switch, and — when the monitor is
-  linked to a printer — live status and progress with **Pause / Resume / Cancel** buttons.
+  sensors, the latest failure **snapshot**, an **Enabled** switch, and - when the monitor is
+  linked to a printer - live status and progress with **Pause / Resume / Cancel** buttons.
   Control is two-way, so Home Assistant dashboards and automations can arm a monitor or stop
   a print, and the hub publishes an availability signal so entities show as unavailable if it
-  goes offline. Monitor state is published on change rather than on every inference frame — a
-  defect or printer-status transition appears at once while the live score updates in steps —
+  goes offline. Monitor state is published on change rather than on every inference frame - a
+  defect or printer-status transition appears at once while the live score updates in steps -
   so monitors never flood Home Assistant's history. The broker is yours and the bridge runs on
   the hub, so no frames leave your hardware. Optional TLS, username/password and custom topic
   prefixes are supported. Anyone
   with access to the broker can control PrintGuard, so treat broker access as you would the
   dashboard.
-- **Accessibility pass** — the dashboard is now fully keyboard-operable and screen-reader
+- **Accessibility pass** - the dashboard is now fully keyboard-operable and screen-reader
   friendly. Every control, camera and monitor tile is reachable by Tab with a clear focus
   outline; dialogs and the monitor panel trap focus while open, close on **Esc** or a click
   outside, lock the page behind them and return focus to wherever you left off; the
@@ -270,8 +270,8 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 ### Fixed
 
 - **WebRTC camera feeds no longer fail silently.** PrintGuard reads cameras with FFmpeg,
-  which cannot ingest WebRTC (WHEP/WHIP) streams. A camera that only offered WebRTC — most
-  often a Klipper/Crowsnest setup on **camera-streamer**, the Crowsnest V5 default — was
+  which cannot ingest WebRTC (WHEP/WHIP) streams. A camera that only offered WebRTC - most
+  often a Klipper/Crowsnest setup on **camera-streamer**, the Crowsnest V5 default - was
   registered but produced no frames, with nothing to say why. Such streams are now detected
   up front: adding one by hand is rejected with a clear message pointing at the MJPEG
   (`…?action=stream`) or RTSP URL to use instead, and a printer that exposes only a WebRTC
@@ -282,14 +282,14 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
   is needed. Webcams already served as MJPEG/HLS are unaffected.
 - **Klipper webcam URLs resolve to the right port.** A webcam advertised by a relative path
   (e.g. `/webcam/?action=stream`) is now fetched from the printer's web port, where the stream
-  is actually served, rather than Moonraker's API port (7125) — which carries no webcam routes
+  is actually served, rather than Moonraker's API port (7125) - which carries no webcam routes
   and silently produced no frames when the printer was added with its `…:7125` base URL.
 
 ## [2.1.1] - 2026-06-19
 
 ### Added
 
-- **Camera rotation** — every camera now has a rotation control (0°, 90°, 180°, 270°) in the
+- **Camera rotation** - every camera now has a rotation control (0°, 90°, 180°, 270°) in the
   camera registry. The rotation is applied to **both** the live view and the frames the
   on-device model runs on, so a camera mounted sideways or upside down can be set upright
   once and everything follows: monitoring, the crop region, REST/MCP snapshots and the
@@ -306,34 +306,34 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 
 ### Added
 
-- **Camera, printer and monitor registries** — printers (OctoPrint, Klipper, Bambu Lab) are
+- **Camera, printer and monitor registries** - printers (OctoPrint, Klipper, Bambu Lab) are
   now registered once in their own registry, exactly like cameras, then picked from a list;
   the registry is the only place to create or delete one. A **monitor** binds a registered
   camera and an optional registered printer and carries the inference thresholds and
   defect-response policy, so one printer connection can back several monitors and its
   connection details are entered once instead of re-typed per printer.
-- **Bambu Lab printers** — link a printer over its local MQTT API alongside the existing
+- **Bambu Lab printers** - link a printer over its local MQTT API alongside the existing
   OctoPrint and Klipper services, with the same pause/cancel-on-defect response, job and
   progress reporting, and inference gating. Enable **LAN Only Mode** and **Developer Mode**
-  on the printer, then link it with its IP, serial number and access code — the form links
+  on the printer, then link it with its IP, serial number and access code - the form links
   Bambu's official setup guide. The protocol is MQTT over TLS, which needs a raw socket the
-  browser sandbox forbids, so Bambu Lab is offered in **hub mode only** — the same
+  browser sandbox forbids, so Bambu Lab is offered in **hub mode only** - the same
   constraint that already makes some notifiers hub-only.
-- **Printer-exposed cameras** — when a registered printer's service exposes a webcam,
+- **Printer-exposed cameras** - when a registered printer's service exposes a webcam,
   PrintGuard registers it as a camera automatically (no stream URL to copy). A camera
   attached to the printer later is picked up from the camera registry's new **Printer
   cameras** tab with a **Refresh** button. Covers OctoPrint and Klipper (Moonraker) webcam
-  streams and the Bambu Lab chamber camera — RTSP on the X1/H2 series and the proprietary
+  streams and the Bambu Lab chamber camera - RTSP on the X1/H2 series and the proprietary
   port-6000 JPEG protocol on the A1/P1 series (hub mode). These cameras are managed by their
   printer: they cannot be removed on their own and are dropped with it, and the REST and MCP
   read surface strips the access codes their sources carry.
-- **Setup guides in config forms** — each printer service and notification channel now
+- **Setup guides in config forms** - each printer service and notification channel now
   shows a one-line setup hint and a link to its official setup docs, so steps taken
   outside PrintGuard (API keys, CORS, bot tokens, webhooks, LAN mode) are spelled out
   where you configure them.
-- **Experimental tag** — a reusable badge that flags new, not-yet-battle-tested features
+- **Experimental tag** - a reusable badge that flags new, not-yet-battle-tested features
   and links to the issue tracker for reports. Bambu Lab carries it.
-- **MCP server and REST API for hub mode** — agents and developers can now drive the
+- **MCP server and REST API for hub mode** - agents and developers can now drive the
   same engine protocol the dashboard speaks. The Model Context Protocol server
   (Streamable HTTP, at `/mcp/`) lets an agent read monitor, printer and camera status, fetch
   the current camera frame as an image, and pause, resume or cancel a print; the versioned
@@ -341,14 +341,14 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
   served as `image/jpeg`. Both are thin transports over the existing engine commands, so
   they never drift from the UI. See
   [docs/api.md](https://github.com/oliverbravery/PrintGuard/blob/main/docs/api.md).
-- **Scoped access tokens, managed from the UI** — capability is configurable per token
+- **Scoped access tokens, managed from the UI** - capability is configurable per token
   through cumulative `read` ⊂ `control` ⊂ `manage` scopes. Issue, name and revoke tokens
   from the dashboard (**Settings → API & MCP access**); each secret (a `pg_…` string) is
   shown once and stored only as a SHA-256 hash, and tokens are managed over the dashboard's
   own protocol, never over the API itself. With no token issued the surface is read-only
   behind your existing auth proxy; issuing scoped tokens unlocks control and management, and
   MCP hides any tool a token cannot use.
-- **Update notifications** — the hub checks the public GitHub releases once a day for a newer
+- **Update notifications** - the hub checks the public GitHub releases once a day for a newer
   version and flags it in the header. A dialog shows the changelog for every version above
   the one you run and the `docker compose pull && docker compose up -d` command to upgrade.
   The check runs server-side with no telemetry and can be switched off in **Settings →
@@ -356,8 +356,8 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 
 ### Changed
 
-- **The dashboard entity is now a "monitor".** What 2.0 called a printer — a camera bound
-  to a service with thresholds — is a monitor; the printer is the registered service
+- **The dashboard entity is now a "monitor".** What 2.0 called a printer - a camera bound
+  to a service with thresholds - is a monitor; the printer is the registered service
   connection it points at. Upgrading from 2.0 preserves registered cameras, but printers
   must be re-registered and their monitors re-created.
 
@@ -375,13 +375,13 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 
 ## [2.0.0] - 2026-06-12
 
-A ground-up rewrite. One Python engine now runs everywhere — in your browser on Pyodide
-or on a server on CPython — with every runtime difference behind a single `Platform`
+A ground-up rewrite. One Python engine now runs everywhere - in your browser on Pyodide
+or on a server on CPython - with every runtime difference behind a single `Platform`
 contract. Nothing from 1.x is migrated: a 2.0 hub starts from a fresh configuration.
 
 ### Added
 
-- **Local mode** — the full engine runs in the browser (Pyodide, with
+- **Local mode** - the full engine runs in the browser (Pyodide, with
   [LiteRT.js](https://developers.google.com/edge/litert) WASM inference). Nothing is
   installed and no frame leaves the device; a
   [live demo](https://oliverbravery.github.io/PrintGuard/) deploys to GitHub Pages on
@@ -389,16 +389,16 @@ contract. Nothing from 1.x is migrated: a 2.0 hub starts from a fresh configurat
 - **Klipper (Moonraker) integration** alongside OctoPrint: read printer state, pause or
   cancel jobs, with per-printer thresholds, consecutive-detection counts and cooldowns.
 - **ntfy, Telegram and Discord notifications**, each carrying a snapshot of the defect.
-- **Live video via MediaMTX** — pull any RTSP/RTMP/HTTP source, publish this device's
+- **Live video via MediaMTX** - pull any RTSP/RTMP/HTTP source, publish this device's
   camera over a WebSocket, auto-discover streams already pushed to the server. Playback
-  is HLS served through the hub's own port, so a single HTTPS port — and the auth proxy
-  in front of it — covers the dashboard, control and video.
-- **Print-aware gating** — printers linked to a service are only watched while they
+  is HLS served through the hub's own port, so a single HTTPS port - and the auth proxy
+  in front of it - covers the dashboard, control and video.
+- **Print-aware gating** - printers linked to a service are only watched while they
   actually print; inference stands by when they sit idle.
-- **Fail-safe watchdog** — warnings on the dashboard and through notification channels
+- **Fail-safe watchdog** - warnings on the dashboard and through notification channels
   when a camera drops, a feed freezes or a printer service stops answering; a failed
   pause is announced, never swallowed.
-- **Fair multi-camera scheduling** — inference capacity is shared evenly across as many
+- **Fair multi-camera scheduling** - inference capacity is shared evenly across as many
   cameras as the hardware sustains.
 
 ### Changed
@@ -409,22 +409,22 @@ contract. Nothing from 1.x is migrated: a 2.0 hub starts from a fresh configurat
   sliders mapped to prototype distances.
 - Cameras are network streams through MediaMTX instead of host devices, so the container
   no longer needs `--privileged`.
-- Securing a hub is delegated to an identity layer in front — Tailscale, Cloudflare
+- Securing a hub is delegated to an identity layer in front - Tailscale, Cloudflare
   Access or oauth2-proxy, documented step by step in
   [docs/deployment.md](https://github.com/oliverbravery/PrintGuard/blob/main/docs/deployment.md)
-  — instead of in-app SSL certificates and tunnel management.
+  - instead of in-app SSL certificates and tunnel management.
 - Docker is the only supported distribution: multi-arch (`amd64`, `arm64`) images on
   [`ghcr.io/oliverbravery/printguard`](https://github.com/oliverbravery/PrintGuard/pkgs/container/printguard),
   with a compose file that includes MediaMTX.
 
 ### Removed
 
-- The PyPI package — use the Docker image, or local mode for an install-free run.
-- Web push notifications and VAPID key setup — replaced by ntfy, Telegram and Discord.
-- The setup page's SSL certificate generation and built-in Cloudflare/ngrok tunnelling —
+- The PyPI package - use the Docker image, or local mode for an install-free run.
+- Web push notifications and VAPID key setup - replaced by ntfy, Telegram and Discord.
+- The setup page's SSL certificate generation and built-in Cloudflare/ngrok tunnelling -
   replaced by
   [docs/deployment.md](https://github.com/oliverbravery/PrintGuard/blob/main/docs/deployment.md).
-- 32-bit ARM (`arm/v7`) images — `arm64` (Raspberry Pi 4/5) remains supported.
+- 32-bit ARM (`arm/v7`) images - `arm64` (Raspberry Pi 4/5) remains supported.
 
 [2.1.0]: https://github.com/oliverbravery/PrintGuard/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/oliverbravery/PrintGuard/compare/v2.0.0...v2.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,7 +83,7 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 
 - **Landing-page macOS install steps match current macOS.** The desktop-app panel on the
   [project site](https://oliverbravery.github.io/PrintGuard/) now shows the macOS Sequoia unlock
-  path - **System Settings → Privacy & Security → Open Anyway** - in place of the old
+  path — **System Settings → Privacy & Security → Open Anyway** — in place of the old
   right-click → **Open** that newer macOS no longer offers. Website copy only; the app and Docker
   image are unchanged.
 
@@ -93,7 +93,7 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 
 - **The macOS app installs like a normal Mac app.** The download now presents PrintGuard beside
   your Applications folder to drag it into, instead of a lone app icon. The builds are still
-  unsigned for now, so the first launch needs one manual approval - and on macOS Sequoia that moved
+  unsigned for now, so the first launch needs one manual approval — and on macOS Sequoia that moved
   from the old right-click → **Open** to **System Settings → Privacy & Security → Open Anyway**
   (double-click the app once, then approve it there).
 
@@ -102,36 +102,36 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 - **API token secrets stay out of the hub's logs.** Generating a token under **Settings → API &
   MCP access** now hands its one-time secret to the dashboard without that secret ever passing
   through the server's log writer, resolving a code-scanning finding about clear-text logging of
-  sensitive data. The token is still shown once and only its hash is stored - nothing about your
+  sensitive data. The token is still shown once and only its hash is stored — nothing about your
   existing tokens changes.
 
 ## [2.3.0] - 2026-07-03
 
 ### Added
 
-- **A desktop app for macOS and Windows - run a hub as an application.** PrintGuard now ships as a
+- **A desktop app for macOS and Windows — run a hub as an application.** PrintGuard now ships as a
   native app that runs the full hub from your menu bar / system tray. Close the window and the hub
   keeps watching, so it covers the multi-hour prints that matter; quit from the tray. The computer's
-  own webcams register straight on the hub - the app's window offers them under **Cameras →
-  This device**, and macOS asks for camera access the first time you register one - so they
+  own webcams register straight on the hub — the app's window offers them under **Cameras →
+  This device**, and macOS asks for camera access the first time you register one — so they
   keep watching with every window closed (Linux Docker hubs can still attach mapped
   `/dev/video*` devices through the API). Reach it from your phone on the same network at `http://<computer>:8000`. Detection still runs entirely on
   your own machine; no frame leaves your hardware. Turn on **Start at login** and forget about it.
   Download it from the landing page or the
-  [Releases page](https://github.com/oliverbravery/PrintGuard/releases) - the builds are unsigned for
+  [Releases page](https://github.com/oliverbravery/PrintGuard/releases) — the builds are unsigned for
   now, so the first launch needs a right-click → **Open** on macOS, or **More info → Run anyway** on
   Windows. On Linux, run the Docker hub as before. When a newer version ships, the update dialog
   offers the right download for your computer; the Docker hub keeps its pull instructions.
 
 - **Native notifications on the desktop app.** The macOS and Windows desktop app can now post
-  defect alerts to the operating system's own notification centre - with the snapshot attached -
+  defect alerts to the operating system's own notification centre — with the snapshot attached —
   so a native banner reaches you even with the window closed and no phone app set up. Turn on
   **Desktop notification** under **Settings → Alerts** (it is offered only inside the desktop app,
   next to ntfy, Telegram and Discord); on macOS, allow notifications for PrintGuard the first time
   it asks. The Docker hub, which has no desktop of its own, keeps using the push channels.
 
-- **Prusa printers now connect over PrusaLink.** Register a Prusa printer - MK4, MK4S, MK3.9,
-  MK3.5, MINI, XL, CORE One, or an MK3/MK2.5 running PrusaLink on a Raspberry Pi - alongside
+- **Prusa printers now connect over PrusaLink.** Register a Prusa printer — MK4, MK4S, MK3.9,
+  MK3.5, MINI, XL, CORE One, or an MK3/MK2.5 running PrusaLink on a Raspberry Pi — alongside
   OctoPrint, Klipper and Bambu. PrintGuard reads its job, progress and state, gates inference
   while it is idle, and can **pause or cancel** the print when a defect holds. Enable PrusaLink
   on the printer, then link it with its URL and the password shown under Settings → Network →
@@ -140,13 +140,13 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
   Prusa is offered in **hub mode only**.
 
 - **Report a bug straight from the dashboard.** Hit the ⚑ chip in the header, describe what
-  happened, attach screenshots and optionally leave an email for follow-up - anonymously, no
+  happened, attach screenshots and optionally leave an email for follow-up — anonymously, no
   account needed. Each report carries a diagnostics bundle (version, platform, configuration,
   recent errors and warnings) with **every credential stripped**, and no camera frames unless
   you attach them yourself. Nothing is ever sent unless you submit a report.
 
-- **Everything leaves a trace.** The hub now logs its whole lifecycle - boot, camera
-  attach/drop, printer actions, alerts, rejected API and socket attempts - to `docker logs`,
+- **Everything leaves a trace.** The hub now logs its whole lifecycle — boot, camera
+  attach/drop, printer actions, alerts, rejected API and socket attempts — to `docker logs`,
   and the desktop app writes a self-rotating `printguard.log` beside its data, so problems on
   a computer with no terminal can still be diagnosed. Bug reports automatically attach the
   recent engine and interface logs, scrubbed of every credential, so a report carries the
@@ -154,7 +154,7 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
   support.
 
 - **A detection history for every monitor.** Open a monitor's detail page to see its defect risk
-  charted over selectable periods, alongside a snapshot of every alert it fired - what the camera
+  charted over selectable periods, alongside a snapshot of every alert it fired — what the camera
   saw at the moment PrintGuard acted.
 
 - **Monitor settings now explain themselves.** The alert threshold, sensitivity and
@@ -162,14 +162,14 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
   it.
 
 - **The `/api/v1` read surface now describes its response bodies.** PrintGuard's API reference
-  (`docs/api.md`) documents the camera and monitor object shapes - including where a camera's
+  (`docs/api.md`) documents the camera and monitor object shapes — including where a camera's
   failure signal lives (`last_result.prediction`), since the smoothed 0–1 defect score is a
   per-monitor quantity, not a field on the camera. The camera and monitor routes now carry
   response schemas too, so the interactive `/api/v1/docs` shows the shapes instead of empty bodies.
 
-- **`POST /api/v1/classify` - score a single supplied frame.** Hand the model a frame directly
+- **`POST /api/v1/classify` — score a single supplied frame.** Hand the model a frame directly
   (POST the bytes as `image/jpeg`, `read` scope, optional `?sensitivity=`) and get back
-  `{prediction, distances, margin, defect_score}` - the same per-frame verdict the scheduler
+  `{prediction, distances, margin, defect_score}` — the same per-frame verdict the scheduler
   produces for a registered camera, without registering one. Useful for an external orchestrator
   that can reach a camera PrintGuard can't (e.g. a cloud tool tunnelling to a LAN printer), or an
   agent wanting a one-off check. Exposed both over REST and as a `classify_frame` MCP tool, so an
@@ -178,7 +178,7 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 
 ### Fixed
 
-- Registering a camera could report "no frames" even though the stream was healthy - the hub
+- Registering a camera could report "no frames" even though the stream was healthy — the hub
   gave a source eight seconds to produce a frame, which a freshly published "this device"
   camera or a slow-starting stream often exceeds. Registration now waits out a cold start
   before giving up.
@@ -188,7 +188,7 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 ### Fixed
 
 - **Bambu A1, A1 mini, P1P and P1S chamber cameras now show up on the dashboard.** Adding one of
-  these printers registered the printer but not its chamber camera - PrintGuard kept probing the
+  these printers registered the printer but not its chamber camera — PrintGuard kept probing the
   live camera stream instead of opening it, so no camera and no video appeared. The stream now
   opens on its first frame and the camera registers like any other. (X1- and H2-series cameras use
   RTSP and were never affected.)
@@ -198,21 +198,21 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 ### Changed
 
 - **One container, no second image, no terminal needed.** PrintGuard now ships as a **single
-  image** with the streaming server built in - there is no separate MediaMTX container to install
+  image** with the streaming server built in — there is no separate MediaMTX container to install
   and no specific version of it to track down (the sticking point on Unraid and similar). Install
   it with a single `docker run`, the now one-service `docker-compose.yaml`, or **one click from
-  Unraid Community Applications**. The hub still serves everything - dashboard, live video and all
-  - on `:8000`; the camera-publish ports `8554`/`1935` are optional and only matter if a camera
-  pushes a stream into PrintGuard. To put it on your network your own way - private over Tailscale,
-  public behind Cloudflare Access or an auth proxy - see the deployment guide.
+  Unraid Community Applications**. The hub still serves everything — dashboard, live video and all
+  — on `:8000`; the camera-publish ports `8554`/`1935` are optional and only matter if a camera
+  pushes a stream into PrintGuard. To put it on your network your own way — private over Tailscale,
+  public behind Cloudflare Access or an auth proxy — see the deployment guide.
 
   *Upgrading from the two-container setup?* Pull the new image and remove the `mediamtx` service
-  (and its `mediamtx.yml` mount) from your compose file - the built-in server replaces it. Your
+  (and its `mediamtx.yml` mount) from your compose file — the built-in server replaces it. Your
   `/data` volume and settings carry over untouched.
 
 - **Settings now save themselves.** Camera image adjustments (brightness, contrast, sharpness,
   rotation, crop) and monitor settings (thresholds, sensitivity, defect response, notifications)
-  now apply **live everywhere the moment you change them** - the camera preview, dashboard tiles
+  now apply **live everywhere the moment you change them** — the camera preview, dashboard tiles
   and risk gauges update as you drag, with no **Save** button to remember. A small **saved ✓**
   indicator confirms each change is stored, and anything still in flight is saved automatically
   when you close the panel. Notification channels, printers and Home Assistant (MQTT) keep an
@@ -223,40 +223,40 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 
 ### Added
 
-- **Built-in guide and a setup checklist** - a new **?** in the header opens a Guide that explains
-  every part of PrintGuard - cameras, printers, monitors, how detection and alerts work, and what
-  you can automate - each with a shortcut that jumps straight to the right place. Until your first
+- **Built-in guide and a setup checklist** — a new **?** in the header opens a Guide that explains
+  every part of PrintGuard — cameras, printers, monitors, how detection and alerts work, and what
+  you can automate — each with a shortcut that jumps straight to the right place. Until your first
   monitor is watching, the dashboard shows a **Getting started** checklist that tracks your progress
   from camera to printer to alerts to monitor, so you always know what to do next. Works the same in
   local (in-browser) mode.
-- **Light, dark and custom themes** - pick **System** (follows your device), **Light** or
+- **Light, dark and custom themes** — pick **System** (follows your device), **Light** or
   **Dark** from the new header toggle or **Settings → Appearance**, or design your own. The
-  theme editor lets you set every colour - surfaces, text, lines and the accent/ok/warn/bad
-  status colours - with a live preview as you go, and your themes are saved and synced to every
+  theme editor lets you set every colour — surfaces, text, lines and the accent/ok/warn/bad
+  status colours — with a live preview as you go, and your themes are saved and synced to every
   browser that opens the hub. The selection defaults to System, so each device follows its own
   light/dark preference until you choose one, and the correct theme paints on load with no
   flash. Works the same in local (in-browser) mode.
-- **Customisable dashboard layout** - tap **Customise** (the ▦ in the header) to arrange the
+- **Customisable dashboard layout** — tap **Customise** (the ▦ in the header) to arrange the
   dashboard around your workflow: drag monitors into any order, **pin** the ones that matter
   to the front, and **hide** the ones you don't, with a tray to bring hidden ones back. The
   camera registry can be reordered and hidden the same way. Dragging works with mouse, touch
   and keyboard, your layout is saved and synced to every browser that opens the hub, and it
   works the same in local (in-browser) mode.
-- **Home Assistant integration over MQTT** - point the hub at your MQTT broker (**Settings →
+- **Home Assistant integration over MQTT** — point the hub at your MQTT broker (**Settings →
   Home Assistant (MQTT)**) and every monitor appears in Home Assistant automatically through
   MQTT discovery, each as its own device: a **Defect** problem sensor, defect-score and state
-  sensors, the latest failure **snapshot**, an **Enabled** switch, and - when the monitor is
-  linked to a printer - live status and progress with **Pause / Resume / Cancel** buttons.
+  sensors, the latest failure **snapshot**, an **Enabled** switch, and — when the monitor is
+  linked to a printer — live status and progress with **Pause / Resume / Cancel** buttons.
   Control is two-way, so Home Assistant dashboards and automations can arm a monitor or stop
   a print, and the hub publishes an availability signal so entities show as unavailable if it
-  goes offline. Monitor state is published on change rather than on every inference frame - a
-  defect or printer-status transition appears at once while the live score updates in steps -
+  goes offline. Monitor state is published on change rather than on every inference frame — a
+  defect or printer-status transition appears at once while the live score updates in steps —
   so monitors never flood Home Assistant's history. The broker is yours and the bridge runs on
   the hub, so no frames leave your hardware. Optional TLS, username/password and custom topic
   prefixes are supported. Anyone
   with access to the broker can control PrintGuard, so treat broker access as you would the
   dashboard.
-- **Accessibility pass** - the dashboard is now fully keyboard-operable and screen-reader
+- **Accessibility pass** — the dashboard is now fully keyboard-operable and screen-reader
   friendly. Every control, camera and monitor tile is reachable by Tab with a clear focus
   outline; dialogs and the monitor panel trap focus while open, close on **Esc** or a click
   outside, lock the page behind them and return focus to wherever you left off; the
@@ -270,8 +270,8 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 ### Fixed
 
 - **WebRTC camera feeds no longer fail silently.** PrintGuard reads cameras with FFmpeg,
-  which cannot ingest WebRTC (WHEP/WHIP) streams. A camera that only offered WebRTC - most
-  often a Klipper/Crowsnest setup on **camera-streamer**, the Crowsnest V5 default - was
+  which cannot ingest WebRTC (WHEP/WHIP) streams. A camera that only offered WebRTC — most
+  often a Klipper/Crowsnest setup on **camera-streamer**, the Crowsnest V5 default — was
   registered but produced no frames, with nothing to say why. Such streams are now detected
   up front: adding one by hand is rejected with a clear message pointing at the MJPEG
   (`…?action=stream`) or RTSP URL to use instead, and a printer that exposes only a WebRTC
@@ -282,14 +282,14 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
   is needed. Webcams already served as MJPEG/HLS are unaffected.
 - **Klipper webcam URLs resolve to the right port.** A webcam advertised by a relative path
   (e.g. `/webcam/?action=stream`) is now fetched from the printer's web port, where the stream
-  is actually served, rather than Moonraker's API port (7125) - which carries no webcam routes
+  is actually served, rather than Moonraker's API port (7125) — which carries no webcam routes
   and silently produced no frames when the printer was added with its `…:7125` base URL.
 
 ## [2.1.1] - 2026-06-19
 
 ### Added
 
-- **Camera rotation** - every camera now has a rotation control (0°, 90°, 180°, 270°) in the
+- **Camera rotation** — every camera now has a rotation control (0°, 90°, 180°, 270°) in the
   camera registry. The rotation is applied to **both** the live view and the frames the
   on-device model runs on, so a camera mounted sideways or upside down can be set upright
   once and everything follows: monitoring, the crop region, REST/MCP snapshots and the
@@ -306,34 +306,34 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 
 ### Added
 
-- **Camera, printer and monitor registries** - printers (OctoPrint, Klipper, Bambu Lab) are
+- **Camera, printer and monitor registries** — printers (OctoPrint, Klipper, Bambu Lab) are
   now registered once in their own registry, exactly like cameras, then picked from a list;
   the registry is the only place to create or delete one. A **monitor** binds a registered
   camera and an optional registered printer and carries the inference thresholds and
   defect-response policy, so one printer connection can back several monitors and its
   connection details are entered once instead of re-typed per printer.
-- **Bambu Lab printers** - link a printer over its local MQTT API alongside the existing
+- **Bambu Lab printers** — link a printer over its local MQTT API alongside the existing
   OctoPrint and Klipper services, with the same pause/cancel-on-defect response, job and
   progress reporting, and inference gating. Enable **LAN Only Mode** and **Developer Mode**
-  on the printer, then link it with its IP, serial number and access code - the form links
+  on the printer, then link it with its IP, serial number and access code — the form links
   Bambu's official setup guide. The protocol is MQTT over TLS, which needs a raw socket the
-  browser sandbox forbids, so Bambu Lab is offered in **hub mode only** - the same
+  browser sandbox forbids, so Bambu Lab is offered in **hub mode only** — the same
   constraint that already makes some notifiers hub-only.
-- **Printer-exposed cameras** - when a registered printer's service exposes a webcam,
+- **Printer-exposed cameras** — when a registered printer's service exposes a webcam,
   PrintGuard registers it as a camera automatically (no stream URL to copy). A camera
   attached to the printer later is picked up from the camera registry's new **Printer
   cameras** tab with a **Refresh** button. Covers OctoPrint and Klipper (Moonraker) webcam
-  streams and the Bambu Lab chamber camera - RTSP on the X1/H2 series and the proprietary
+  streams and the Bambu Lab chamber camera — RTSP on the X1/H2 series and the proprietary
   port-6000 JPEG protocol on the A1/P1 series (hub mode). These cameras are managed by their
   printer: they cannot be removed on their own and are dropped with it, and the REST and MCP
   read surface strips the access codes their sources carry.
-- **Setup guides in config forms** - each printer service and notification channel now
+- **Setup guides in config forms** — each printer service and notification channel now
   shows a one-line setup hint and a link to its official setup docs, so steps taken
   outside PrintGuard (API keys, CORS, bot tokens, webhooks, LAN mode) are spelled out
   where you configure them.
-- **Experimental tag** - a reusable badge that flags new, not-yet-battle-tested features
+- **Experimental tag** — a reusable badge that flags new, not-yet-battle-tested features
   and links to the issue tracker for reports. Bambu Lab carries it.
-- **MCP server and REST API for hub mode** - agents and developers can now drive the
+- **MCP server and REST API for hub mode** — agents and developers can now drive the
   same engine protocol the dashboard speaks. The Model Context Protocol server
   (Streamable HTTP, at `/mcp/`) lets an agent read monitor, printer and camera status, fetch
   the current camera frame as an image, and pause, resume or cancel a print; the versioned
@@ -341,14 +341,14 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
   served as `image/jpeg`. Both are thin transports over the existing engine commands, so
   they never drift from the UI. See
   [docs/api.md](https://github.com/oliverbravery/PrintGuard/blob/main/docs/api.md).
-- **Scoped access tokens, managed from the UI** - capability is configurable per token
+- **Scoped access tokens, managed from the UI** — capability is configurable per token
   through cumulative `read` ⊂ `control` ⊂ `manage` scopes. Issue, name and revoke tokens
   from the dashboard (**Settings → API & MCP access**); each secret (a `pg_…` string) is
   shown once and stored only as a SHA-256 hash, and tokens are managed over the dashboard's
   own protocol, never over the API itself. With no token issued the surface is read-only
   behind your existing auth proxy; issuing scoped tokens unlocks control and management, and
   MCP hides any tool a token cannot use.
-- **Update notifications** - the hub checks the public GitHub releases once a day for a newer
+- **Update notifications** — the hub checks the public GitHub releases once a day for a newer
   version and flags it in the header. A dialog shows the changelog for every version above
   the one you run and the `docker compose pull && docker compose up -d` command to upgrade.
   The check runs server-side with no telemetry and can be switched off in **Settings →
@@ -356,8 +356,8 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 
 ### Changed
 
-- **The dashboard entity is now a "monitor".** What 2.0 called a printer - a camera bound
-  to a service with thresholds - is a monitor; the printer is the registered service
+- **The dashboard entity is now a "monitor".** What 2.0 called a printer — a camera bound
+  to a service with thresholds — is a monitor; the printer is the registered service
   connection it points at. Upgrading from 2.0 preserves registered cameras, but printers
   must be re-registered and their monitors re-created.
 
@@ -375,13 +375,13 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 
 ## [2.0.0] - 2026-06-12
 
-A ground-up rewrite. One Python engine now runs everywhere - in your browser on Pyodide
-or on a server on CPython - with every runtime difference behind a single `Platform`
+A ground-up rewrite. One Python engine now runs everywhere — in your browser on Pyodide
+or on a server on CPython — with every runtime difference behind a single `Platform`
 contract. Nothing from 1.x is migrated: a 2.0 hub starts from a fresh configuration.
 
 ### Added
 
-- **Local mode** - the full engine runs in the browser (Pyodide, with
+- **Local mode** — the full engine runs in the browser (Pyodide, with
   [LiteRT.js](https://developers.google.com/edge/litert) WASM inference). Nothing is
   installed and no frame leaves the device; a
   [live demo](https://oliverbravery.github.io/PrintGuard/) deploys to GitHub Pages on
@@ -389,16 +389,16 @@ contract. Nothing from 1.x is migrated: a 2.0 hub starts from a fresh configurat
 - **Klipper (Moonraker) integration** alongside OctoPrint: read printer state, pause or
   cancel jobs, with per-printer thresholds, consecutive-detection counts and cooldowns.
 - **ntfy, Telegram and Discord notifications**, each carrying a snapshot of the defect.
-- **Live video via MediaMTX** - pull any RTSP/RTMP/HTTP source, publish this device's
+- **Live video via MediaMTX** — pull any RTSP/RTMP/HTTP source, publish this device's
   camera over a WebSocket, auto-discover streams already pushed to the server. Playback
-  is HLS served through the hub's own port, so a single HTTPS port - and the auth proxy
-  in front of it - covers the dashboard, control and video.
-- **Print-aware gating** - printers linked to a service are only watched while they
+  is HLS served through the hub's own port, so a single HTTPS port — and the auth proxy
+  in front of it — covers the dashboard, control and video.
+- **Print-aware gating** — printers linked to a service are only watched while they
   actually print; inference stands by when they sit idle.
-- **Fail-safe watchdog** - warnings on the dashboard and through notification channels
+- **Fail-safe watchdog** — warnings on the dashboard and through notification channels
   when a camera drops, a feed freezes or a printer service stops answering; a failed
   pause is announced, never swallowed.
-- **Fair multi-camera scheduling** - inference capacity is shared evenly across as many
+- **Fair multi-camera scheduling** — inference capacity is shared evenly across as many
   cameras as the hardware sustains.
 
 ### Changed
@@ -409,22 +409,22 @@ contract. Nothing from 1.x is migrated: a 2.0 hub starts from a fresh configurat
   sliders mapped to prototype distances.
 - Cameras are network streams through MediaMTX instead of host devices, so the container
   no longer needs `--privileged`.
-- Securing a hub is delegated to an identity layer in front - Tailscale, Cloudflare
+- Securing a hub is delegated to an identity layer in front — Tailscale, Cloudflare
   Access or oauth2-proxy, documented step by step in
   [docs/deployment.md](https://github.com/oliverbravery/PrintGuard/blob/main/docs/deployment.md)
-  - instead of in-app SSL certificates and tunnel management.
+  — instead of in-app SSL certificates and tunnel management.
 - Docker is the only supported distribution: multi-arch (`amd64`, `arm64`) images on
   [`ghcr.io/oliverbravery/printguard`](https://github.com/oliverbravery/PrintGuard/pkgs/container/printguard),
   with a compose file that includes MediaMTX.
 
 ### Removed
 
-- The PyPI package - use the Docker image, or local mode for an install-free run.
-- Web push notifications and VAPID key setup - replaced by ntfy, Telegram and Discord.
-- The setup page's SSL certificate generation and built-in Cloudflare/ngrok tunnelling -
+- The PyPI package — use the Docker image, or local mode for an install-free run.
+- Web push notifications and VAPID key setup — replaced by ntfy, Telegram and Discord.
+- The setup page's SSL certificate generation and built-in Cloudflare/ngrok tunnelling —
   replaced by
   [docs/deployment.md](https://github.com/oliverbravery/PrintGuard/blob/main/docs/deployment.md).
-- 32-bit ARM (`arm/v7`) images - `arm64` (Raspberry Pi 4/5) remains supported.
+- 32-bit ARM (`arm/v7`) images — `arm64` (Raspberry Pi 4/5) remains supported.
 
 [2.1.0]: https://github.com/oliverbravery/PrintGuard/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/oliverbravery/PrintGuard/compare/v2.0.0...v2.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
   resumes it automatically when printing or viewing starts. RTSP, RTMP and WHEP feeds are pulled
   on demand, while MJPEG, Bambu and device cameras keep their existing browser-compatible H.264
   bridge without running it unnecessarily. Unknown or unreachable printers remain monitored.
+- **Desktop webcams now preview immediately after registration.** The camera stays live while its
+  preview connects, then still enters standby after viewing or monitoring stops.
 
 ## [2.3.5] - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,8 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
   on demand, while MJPEG, Bambu and device cameras keep their existing browser-compatible H.264
   bridge without running it unnecessarily. Unknown or unreachable printers remain monitored.
 - **Desktop webcams now preview immediately after registration.** The camera stays live while its
-  preview connects, then still enters standby after viewing or monitoring stops.
+  preview connects, then still enters standby after viewing or monitoring stops. Slow desktop
+  camera startup no longer leaves orphaned captures running after the window closes.
 
 ## [2.3.5] - 2026-07-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ release notes.
 The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.6] - 2026-07-16
+
+### Fixed
+
+- **Idle cameras no longer keep decoding and converting every frame.** When a printer is
+  positively idle and nobody is viewing its feed, PrintGuard puts the camera in standby and
+  resumes it automatically when printing or viewing starts. RTSP, RTMP and WHEP feeds are pulled
+  on demand, while MJPEG, Bambu and device cameras keep their existing browser-compatible H.264
+  bridge without running it unnecessarily. Unknown or unreachable printers remain monitored.
+
 ## [2.3.5] - 2026-07-15
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ cd web && npm run build                   # production UI build
 python printguard/pysrc.py web/public/pysrc.zip   # rebuild the Pyodide source archive for the static demo
 ```
 
-There is no separate Python lint step in the project's required checks — `uv run pytest`
+There is no separate Python lint step in the project's required checks - `uv run pytest`
 and `npm run typecheck` are the gates (see CONTRIBUTING.md "Release cycle").
 
 ## Architecture
@@ -42,7 +42,7 @@ essentials a change must respect:
   [`engine/engine.py`](printguard/engine/engine.py) dispatches commands through its
   `_handlers` map and broadcasts events to subscribed transport "sinks". `state_event()`
   is the full snapshot the UI renders; any new engine-owned data the UI needs is added
-  there. The UI is **presentation-only** — it never holds logic the engine should own. The
+  there. The UI is **presentation-only** - it never holds logic the engine should own. The
   transport is a WebSocket in hub mode and an in-page Pyodide bridge in local mode, and the
   engine cannot tell which.
 
@@ -57,7 +57,7 @@ essentials a change must respect:
   ([`engine/notifiers/`](printguard/engine/notifiers/)) subclass the contracts in
   [`engine/adapters.py`](printguard/engine/adapters.py), talk to the outside world *only*
   through `platform.http`, and are registered in their package `__init__.py`. Adding one
-  needs no other change in either mode — the config form, connection test, polling and
+  needs no other change in either mode - the config form, connection test, polling and
   actions all follow from the adapter. CONTRIBUTING.md has the step-by-step.
 
 - **Programmatic surface is hub-only.** The REST API (`server/api.py`, `/api/v1`) and MCP
@@ -70,7 +70,7 @@ essentials a change must respect:
 
 - **Fail safe, fail loud.** A monitor's `watching` state gates inference; only a *positive*
   "not printing" stands it down (losing the signal keeps watching). Nothing on the alert
-  path swallows errors — failed printer actions, notifier failures and dropped feeds emit
+  path swallows errors - failed printer actions, notifier failures and dropped feeds emit
   `error`/`warning` events. See `engine/watchdog.py`.
 
 - **State** persists through `platform.load_state()`/`save_state()` (a JSON file on the
@@ -79,7 +79,7 @@ essentials a change must respect:
 ## Conventions
 
 - **No comments; let names document intent.** The TypeScript/React UI carries **no** comments
-  or JSDoc — never narrate what the code does. In the Python engine/server, every module, class
+  or JSDoc - never narrate what the code does. In the Python engine/server, every module, class
   and public method gets a docstring, but still no inline comments unless the *why* is genuinely
   non-obvious.
 - **Minimal and consolidated.** No fallbacks, defensive guards or speculative abstractions
@@ -98,7 +98,7 @@ essentials a change must respect:
 
 Merging to `main` ships a release, so every PR carries its own metadata: a version bump and
 a matching top section in [CHANGELOG.md](CHANGELOG.md) ([Keep a Changelog](https://keepachangelog.com)
-form), which is published **verbatim** as the GitHub release notes — write it for someone
+form), which is published **verbatim** as the GitHub release notes - write it for someone
 deciding whether to pull the new image, not about the implementation. Three required checks
 must pass: **tests**, the production **image** build, and **version** (bumped past the last
 release with a matching changelog section). Docker is the only supported distribution.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@ state handling extend the former; a new adapter gets its payloads tested in the 
 ## Regenerating the docs screenshots
 
 The images in `docs/assets/` are rendered from fake data (no backend, broker or video feed)
-by a Playwright script — regenerate them whenever the UI changes:
+by a Playwright script - regenerate them whenever the UI changes:
 
 ```bash
 cd web
@@ -53,17 +53,17 @@ platform's HTTP function.
 
 1. Create `printguard/engine/integrations/<service>.py` subclassing
    [`IntegrationAdapter`](printguard/engine/integrations/base.py):
-   - implement `fetch_state()`, normalising to the canonical `DeviceStatus` values —
+   - implement `fetch_state()`, normalising to the canonical `DeviceStatus` values -
      `offline` must mean "unreachable", not "idle", because it keeps inference watching;
    - implement `send()` for pause/resume/cancel, raising `RuntimeError` on rejection;
    - describe the config form as a JSON Schema (`secret: true` masks fields,
      `placeholder` hints at the expected value);
-   - set `docs_url` to the official API reference — it is required for review.
+   - set `docs_url` to the official API reference - it is required for review.
 2. Register an instance in
    [`integrations/__init__.py`](printguard/engine/integrations/__init__.py).
 
 The configuration form, connection test, device polling, inference gating and defect
-actions all follow from the adapter — no other change in either mode.
+actions all follow from the adapter - no other change in either mode.
 
 ## Adding a notification provider
 
@@ -75,7 +75,7 @@ Notifiers deliver defect snapshots and watchdog warnings.
      service supports uploads (`multipart_form()` in the same module builds the body),
      and raise `RuntimeError` with the service's error detail on rejection;
    - set `browser_ok = False` if the service sends no CORS headers (it will be offered
-     in hub mode only — check from a browser console before assuming);
+     in hub mode only - check from a browser console before assuming);
    - JSON-schema config and `docs_url`, exactly as for integrations.
 2. Register an instance in
    [`notifiers/__init__.py`](printguard/engine/notifiers/__init__.py).
@@ -86,7 +86,7 @@ adapter.
 ## Ground rules
 
 - **No mode forks.** If shared code needs something runtime-specific, extend the
-  `Platform` protocol on both sides with identical signatures — never branch on mode.
+  `Platform` protocol on both sides with identical signatures - never branch on mode.
 - **Fail loudly.** Anything on the alert path that can fail must emit an `error` or
   `warning` event. No bare `except: pass` where a user would want to know.
 - **Minimal code.** Prefer consolidating existing code over adding parallel variants;
@@ -115,12 +115,12 @@ Then add a matching section at the top of [CHANGELOG.md](CHANGELOG.md) in
 The section is published verbatim as the GitHub release notes, so describe the
 user-visible effect, not the implementation.
 
-A PR can only merge once three required checks pass —
+A PR can only merge once three required checks pass -
 
-- **tests** — the engine simulation suite;
-- **image** — the production Docker image must build, so a change that breaks the image
+- **tests** - the engine simulation suite;
+- **image** - the production Docker image must build, so a change that breaks the image
   can never reach `main`;
-- **version** — the version must be bumped past the last release and have a matching
+- **version** - the version must be bumped past the last release and have a matching
   `CHANGELOG.md` section, so every merge ships as a unique, documented, immutable
   version (re-publishing an existing tag is refused).
 
@@ -129,7 +129,7 @@ On merge, the [release workflow](.github/workflows/release.yml):
 1. builds and pushes the multi-arch image to `ghcr.io/oliverbravery/printguard`,
    tagged `X.Y.Z`, `X.Y` and `latest`;
 2. only after the image is published, tags the merge commit `vX.Y.Z` and creates the
-   GitHub release with the changelog section as its notes — a failed build never
+   GitHub release with the changelog section as its notes - a failed build never
    becomes a release;
 3. deploys the in-browser demo to GitHub Pages;
 4. builds the macOS and Windows desktop apps and attaches them to the release.

--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@
 
 **PrintGuard watches your 3D printer cameras with an on-device vision model, pauses the
 printer the moment a print starts to fail, and sends a snapshot to your phone.** No cloud, no
-subscription, no account — your camera frames never leave hardware you own.
+subscription, no account - your camera frames never leave hardware you own.
 
 ![PrintGuard dashboard: three cameras at a glance, one print mid-failure and auto-paused](docs/assets/dashboard.png)
 
-## Try it now — nothing to install
+## Try it now - nothing to install
 
 **[oliverbravery.github.io/PrintGuard](https://oliverbravery.github.io/PrintGuard/)** runs the
 *entire* engine in your browser. Point your webcam at a print and watch it score each frame
@@ -24,32 +24,32 @@ real, [jump to Quick start](#quick-start).
 
 ## What you get
 
-- **Failures caught early** — a compact vision model scores every frame and acts the moment a
+- **Failures caught early** - a compact vision model scores every frame and acts the moment a
   defect holds, so spaghetti and detachments don't run for hours (or burn through a spool).
-- **Damage stopped for you** — a sustained defect can pause or cancel the print through
+- **Damage stopped for you** - a sustained defect can pause or cancel the print through
   OctoPrint, Klipper, Elegoo, Prusa (PrusaLink) or Bambu Lab, with sensitivity, thresholds and
   cooldowns you set per monitor.
-- **A heads-up on your phone** — the instant a defect holds, a snapshot lands over ntfy,
+- **A heads-up on your phone** - the instant a defect holds, a snapshot lands over ntfy,
   Telegram or Discord.
-- **Quiet when nothing's wrong** — printers linked to a service are only watched while they
+- **Quiet when nothing's wrong** - printers linked to a service are only watched while they
   actually print; inference rests when they're idle and wakes when a job starts.
-- **Loud when something is** — a dropped camera, frozen feed or unresponsive printer warns you
+- **Loud when something is** - a dropped camera, frozen feed or unresponsive printer warns you
   on the dashboard *and* your phone. If PrintGuard can't tell whether a printer is printing,
-  it keeps watching — losing the signal never silently stops monitoring.
-- **Every printer on one screen** — one machine shares inference fairly across as many cameras
+  it keeps watching - losing the signal never silently stops monitoring.
+- **Every printer on one screen** - one machine shares inference fairly across as many cameras
   as your hardware can sustain.
 
 ## Make it yours
 
-Choose a look — **System**, **Light**, **Dark**, or design your own in the built-in theme
-editor — from the header. Your themes are saved and synced to every browser that opens the hub.
+Choose a look - **System**, **Light**, **Dark**, or design your own in the built-in theme
+editor - from the header. Your themes are saved and synced to every browser that opens the hub.
 
 | Dark | Light |
 |:---:|:---:|
 | ![Dark theme](docs/assets/dashboard.png) | ![Light theme](docs/assets/dashboard-light.png) |
 
 Tap **Customise** to arrange the dashboard around how *you* work: drag monitors into any
-order, **pin** the ones that matter to the front, and **hide** the rest — with a tray to bring
+order, **pin** the ones that matter to the front, and **hide** the rest - with a tray to bring
 them back. The camera rail rearranges the same way.
 
 ![Customise mode: drag to reorder, pin and hide monitors and cameras](docs/assets/customise.png)
@@ -60,9 +60,9 @@ Open any monitor for its live risk score, score history and one-tap printer cont
 
 ## Quick start
 
-### Desktop app — macOS & Windows
+### Desktop app - macOS & Windows
 
-The easiest way to run a hub on the computer next to your printer: a native app — no Docker, no
+The easiest way to run a hub on the computer next to your printer: a native app - no Docker, no
 terminal. It lives in your **menu bar / system tray**, so closing the window leaves the hub running
 and the printer watched; quit from the tray when you're done. Reach it from your phone on the same
 network at `http://<computer>:8000`. Nothing leaves your machine.
@@ -80,9 +80,9 @@ so the first launch needs one manual approval: on macOS, double-click the app, t
 **System Settings → Privacy & Security** and click **Open Anyway** under *Security*; on Windows,
 choose **More info → Run anyway**. On Linux, run the [Docker hub](#docker--for-an-always-on-server-or-nas) instead.
 
-### Docker — for an always-on server or NAS
+### Docker - for an always-on server or NAS
 
-PrintGuard is a **single container** — install with one command:
+PrintGuard is a **single container** - install with one command:
 
 ```bash
 docker run -d --name printguard --restart unless-stopped \
@@ -94,11 +94,11 @@ docker run -d --name printguard --restart unless-stopped \
 Open `http://<host>:8000`, pick a mode, register a camera and your printer, then add a monitor
 that binds them.
 
-- **Unraid** — add **PrintGuard** from Community Applications (or import the
+- **Unraid** - add **PrintGuard** from Community Applications (or import the
   [template](templates/printguard.xml)) and install from the UI; no terminal needed.
-- **Docker Compose** — prefer a file? [`docker-compose.yaml`](docker-compose.yaml): `curl -fsSLO https://raw.githubusercontent.com/oliverbravery/PrintGuard/main/docker-compose.yaml && docker compose up -d`.
+- **Docker Compose** - prefer a file? [`docker-compose.yaml`](docker-compose.yaml): `curl -fsSLO https://raw.githubusercontent.com/oliverbravery/PrintGuard/main/docker-compose.yaml && docker compose up -d`.
 
-Ports `8554`/`1935` only matter for cameras that *push* a stream into PrintGuard — most setups
+Ports `8554`/`1935` only matter for cameras that *push* a stream into PrintGuard - most setups
 (URL pull, Bambu, or "this device") can leave them off. Images for `amd64` and `arm64`
 (Raspberry Pi 4/5) are published to
 [`ghcr.io/oliverbravery/printguard`](https://github.com/oliverbravery/PrintGuard/pkgs/container/printguard)
@@ -106,7 +106,7 @@ on every release.
 
 ## Two modes, one engine
 
-The same detection engine runs in two places — try it instantly in the browser, then self-host
+The same detection engine runs in two places - try it instantly in the browser, then self-host
 it when you're ready.
 
 | | Local mode | Hub mode |
@@ -116,40 +116,40 @@ it when you're ready.
 | Frames leave the device | never | only to your own server |
 | Survives closing the tab | no | yes |
 
-The **desktop app** (macOS and Windows) is hub mode without the setup — the same persistent engine
+The **desktop app** (macOS and Windows) is hub mode without the setup - the same persistent engine
 as the container, in a native window on (and never leaving) your own computer.
 
 ## Printers, cameras and alerts
 
-Register your printer — OctoPrint, Klipper (Moonraker), Elegoo, Prusa (PrusaLink) or Bambu Lab —
+Register your printer - OctoPrint, Klipper (Moonraker), Elegoo, Prusa (PrusaLink) or Bambu Lab -
 bind it to a monitor, and choose what a sustained defect does: alert, pause or cancel. If a
 printer exposes a webcam, PrintGuard adds it as a camera for you. Turn on ntfy, Telegram,
 Discord, or (in the desktop app) native OS notifications in **Settings** to get snapshot alerts
 and watchdog warnings.
 
-Connecting over Docker or HTTPS, or linking an Elegoo, Prusa or Bambu printer, has a few gotchas — the full
+Connecting over Docker or HTTPS, or linking an Elegoo, Prusa or Bambu printer, has a few gotchas - the full
 walk-through (and webcam/camera options) lives in **[docs/printers.md](docs/printers.md)**.
 
 ## Exposing a hub safely
 
 PrintGuard ships no auth, so put an identity layer in front before anything leaves your trusted
-network — never port-forward the hub's ports directly.
+network - never port-forward the hub's ports directly.
 **[docs/deployment.md](docs/deployment.md)** has step-by-step setups for **Tailscale**
 (recommended), **Cloudflare Tunnel + Access** and **oauth2-proxy**, plus a hardening checklist.
 
 ## Home Assistant
 
 Point the hub at your MQTT broker (**Settings → Home Assistant**) and every monitor appears in
-Home Assistant automatically through MQTT discovery — a defect sensor, defect score, the latest
+Home Assistant automatically through MQTT discovery - a defect sensor, defect score, the latest
 failure snapshot, an **Enabled** switch, and, for linked printers, live status with **Pause**,
 **Resume** and **Cancel**. Control is two-way, so your automations can drive PrintGuard. The
 broker is yours and the bridge runs on the hub, so no frames leave your hardware.
 
-## Automate it — MCP and API
+## Automate it - MCP and API
 
 A hub exposes its engine to agents and scripts through the same protocol the dashboard uses, so
 anything the UI can do is automatable. Point an MCP client (Claude, an IDE) at
-`https://<host>/mcp/`, or use the REST API at `/api/v1` — both can read printer and camera
+`https://<host>/mcp/`, or use the REST API at `/api/v1` - both can read printer and camera
 status, fetch the **current camera frame as an image**, and pause/resume/cancel. Capability is
 per token: issue scoped bearer tokens (**read** ⊂ **control** ⊂ **manage**) from **Settings**,
 and an agent only gets what you grant. Full reference: **[docs/api.md](docs/api.md)**.
@@ -164,11 +164,11 @@ prototype distances, so you can tune for your camera and lighting without retrai
 
 ## For developers
 
-- [docs/architecture.md](docs/architecture.md) — how one engine runs on CPython and in the
+- [docs/architecture.md](docs/architecture.md) - how one engine runs on CPython and in the
   browser, the platform contract, the scheduler and the fail-safe design, with diagrams.
-- [docs/printers.md](docs/printers.md) — connecting printers and cameras, and the networking
+- [docs/printers.md](docs/printers.md) - connecting printers and cameras, and the networking
   gotchas (Docker, CORS, HTTPS, Bambu).
-- [docs/api.md](docs/api.md) — the hub's MCP server and REST API: scoped access tokens, every
+- [docs/api.md](docs/api.md) - the hub's MCP server and REST API: scoped access tokens, every
   endpoint and tool, and client setup.
-- [CONTRIBUTING.md](CONTRIBUTING.md) — dev setup, tests, and step-by-step guides for adding
+- [CONTRIBUTING.md](CONTRIBUTING.md) - dev setup, tests, and step-by-step guides for adding
   printer integrations and notification providers.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,7 +1,7 @@
 # Third-party notices
 
 PrintGuard's Docker image bundles the following third-party software as a separate,
-unmodified binary (mere aggregation — it runs as its own process and is not linked into
+unmodified binary (mere aggregation - it runs as its own process and is not linked into
 PrintGuard). Each is distributed under its own licence, reproduced below.
 
 ## MediaMTX

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,7 +1,7 @@
 # API & MCP
 
 A PrintGuard **hub** exposes its engine to agents and developers through two transports
-over one protocol — the same commands the dashboard sends, so nothing here can drift from
+over one protocol - the same commands the dashboard sends, so nothing here can drift from
 the UI:
 
 - a **Model Context Protocol** server at `/mcp/` (Streamable HTTP) for agents, and
@@ -11,7 +11,7 @@ Both are hub-only. Local (in-browser) mode has no server to host them.
 
 ## Authentication & scopes
 
-PrintGuard ships no identity layer of its own — put a proxy in front of the hub
+PrintGuard ships no identity layer of its own - put a proxy in front of the hub
 ([docs/deployment.md](deployment.md)). On top of that, the API and MCP surface is gated by
 **capability scopes** so you can decide exactly what an agent may do.
 
@@ -23,9 +23,9 @@ Scopes are cumulative:
 | `control` | everything in `read`, plus pause / resume / cancel a print |
 | `manage` | everything in `control`, plus add/remove/edit cameras, printers and monitors, change settings, test printer services and notifiers, discover cameras |
 
-Issue scoped **bearer tokens** from the dashboard — **Settings → API & MCP access**. Name a
+Issue scoped **bearer tokens** from the dashboard - **Settings → API & MCP access**. Name a
 token, choose its scope and **Generate**; the full secret (a `pg_…` string) is shown
-**once**, so copy it then. Only a hash is stored, so a token can never be retrieved later —
+**once**, so copy it then. Only a hash is stored, so a token can never be retrieved later -
 if one is lost, revoke it and issue another. Revoking takes effect immediately.
 
 ```http
@@ -33,12 +33,12 @@ Authorization: Bearer pg_Zr8...agent
 ```
 
 - **No tokens issued (default):** the surface is **read-only** and trusts whatever
-  fronts it — control and management stay closed until you issue a token.
+  fronts it - control and management stay closed until you issue a token.
 - **Any token issued:** a valid bearer is required for every request; its scope
   decides what it can reach. MCP additionally **hides** tools a token cannot use.
 
 Tokens are stored hashed and are managed only from the UI (behind your proxy), never over
-the API itself — an agent holding a `manage` token can drive printers and cameras but
+the API itself - an agent holding a `manage` token can drive printers and cameras but
 cannot mint or escalate tokens. Serve the hub over HTTPS so tokens are never sent in clear.
 
 ## REST API
@@ -65,14 +65,14 @@ Base path `/api/v1`. Requests and responses are JSON, except the camera frame, w
 | `POST` | `/printers` | manage | Register a printer |
 | `PATCH` | `/printers/{id}` | manage | Update a printer |
 | `DELETE` | `/printers/{id}` | manage | Remove a printer |
-| `POST` | `/printers/test` | manage | `{"provider", "config"}` — reachability |
+| `POST` | `/printers/test` | manage | `{"provider", "config"}` - reachability |
 | `POST` | `/cameras` | manage | Add a camera |
 | `PATCH` | `/cameras/{id}` | manage | Update a camera |
 | `DELETE` | `/cameras/{id}` | manage | Remove a camera |
 | `POST` | `/cameras/discover` | manage | List attachable, unregistered sources |
 | `POST` | `/cameras/refresh-printers` | manage | Register cameras newly exposed by registered printers |
 | `PATCH` | `/settings` | manage | Update settings (e.g. notifiers) |
-| `POST` | `/notifiers/test` | manage | `{"provider", "config"}` — send a test |
+| `POST` | `/notifiers/test` | manage | `{"provider", "config"}` - send a test |
 
 Interactive schema (OpenAPI) is served at `/api/v1/docs`.
 
@@ -129,7 +129,7 @@ npx @modelcontextprotocol/inspector
 
 ## The resource model
 
-Cameras and printers are **registered resources** — each is created and deleted only
+Cameras and printers are **registered resources** - each is created and deleted only
 through its own collection (`/cameras`, `/printers`). A **monitor** binds one camera and,
 optionally, one printer (by `camera_id` / `printer_id`) and carries the inference
 thresholds and defect-response policy; removing a resource clears it from any monitor that
@@ -142,16 +142,16 @@ MCP response; only the dashboard's own WebSocket, behind your proxy, receives th
 Every printer integration (OctoPrint, Klipper/Moonraker, Elegoo, PrusaLink, Bambu Lab, …) is normalised to one
 shape, so a printer reads and controls the same way regardless of its service.
 
-- **Status** — one of `printing`, `paused`, `idle`, `error`, `offline`, `unknown`.
-- **State** — `{ "status", "progress" (0–100), "job" }`, reported on printer objects as
+- **Status** - one of `printing`, `paused`, `idle`, `error`, `offline`, `unknown`.
+- **State** - `{ "status", "progress" (0–100), "job" }`, reported on printer objects as
   `device_state`.
-- **Actions** — `pause`, `resume`, `cancel`.
+- **Actions** - `pause`, `resume`, `cancel`.
 
 ## Reading detection state
 
 The response bodies below are what an integrator polls to answer "is this print failing?".
 Two facts matter and are easy to miss: the **camera** carries a per-frame *classification*,
-while the smoothed **0–1 defect score** is a per-**monitor** quantity — the camera object has
+while the smoothed **0–1 defect score** is a per-**monitor** quantity - the camera object has
 no numeric score field.
 
 **Camera object** (`GET /cameras`, `GET /cameras/{id}`):
@@ -175,7 +175,7 @@ no numeric score field.
 
 `last_result` is the newest raw classification, or `null` before the camera has been
 inferred. `prediction` is simply the **nearest class prototype** for that frame (no
-threshold applied) — the quickest per-camera "failing?" read. It is `"unknown"` when the
+threshold applied) - the quickest per-camera "failing?" read. It is `"unknown"` when the
 frame can't be classified (e.g. the embedding isn't finite).
 
 **Monitor object** (`GET /monitors`, `GET /monitors/{id}`): binds a camera (+ optional

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -3,7 +3,7 @@
 PrintGuard is a monolith where the engine is shared code and runs unchanged on
 CPython (hub mode) and on Pyodide in the browser (local mode). Everything
 mode-specific is confined to one `Platform` implementation per runtime. The two modes
-cannot drift apart because there is nothing to drift — they execute the same files.
+cannot drift apart because there is nothing to drift - they execute the same files.
 
 ```mermaid
 flowchart LR
@@ -49,7 +49,7 @@ needs but cannot implement portably. Identical signatures, different runtimes:
 | `encode_jpeg(rgb)` | PyAV mjpeg | canvas `toBlob` |
 | `load_state` / `save_state` | `data/state.json` | `localStorage` |
 
-The UI is presentation-only and speaks one JSON command/event protocol — over a WebSocket
+The UI is presentation-only and speaks one JSON command/event protocol - over a WebSocket
 in hub mode, over an in-page Pyodide bridge in local mode. The engine cannot tell which
 transport it is on. **Never add mode-specific logic anywhere else**; if a feature needs a
 runtime service, extend the Platform contract on both sides.
@@ -81,9 +81,9 @@ Events (engine → UI): a full `state` snapshot (on connect, after every command
 `report_sent` and `error` events.
 
 `report.send` is the anonymous bug report ([`engine/reports.py`](../printguard/engine/reports.py)):
-one user-initiated POST of a Sentry feedback envelope — description, optional contact email,
+one user-initiated POST of a Sentry feedback envelope - description, optional contact email,
 user-attached files, a diagnostics bundle and the engine and UI log tails, with every
-credential redacted — through `platform.http`, so it works identically in both modes. There
+credential redacted - through `platform.http`, so it works identically in both modes. There
 is no SDK and no automatic telemetry; nothing is sent unless the user submits a report.
 
 ## Logging
@@ -93,7 +93,7 @@ points call it once and records flow to stdout for `docker logs`, to a rotating 
 no console exists (the desktop app sets `LOG_FILE` in its data directory), and into a
 bounded in-memory tail. Emitted alert, warning, error and device events are logged as they
 broadcast, so the tail carries the same timeline the UI shows plus the lifecycle around it
-— boot, camera attach/drop, resource registration, printer actions, API and socket denials.
+- boot, camera attach/drop, resource registration, printer actions, API and socket denials.
 Uvicorn runs without its own log config so its records land in the same handlers. The UI
 keeps its own ring ([`web/src/log.ts`](../web/src/log.ts)) of boot milestones, socket drops,
 toasts, console warnings/errors and uncaught exceptions. Bug reports attach both tails,
@@ -103,7 +103,7 @@ exception tracebacks.
 ## The programmatic surface (hub only)
 
 The MCP server, REST API and Home Assistant MQTT bridge are thin transports over the same
-commands the UI sends — they add no logic of their own, so they cannot drift from the
+commands the UI sends - they add no logic of their own, so they cannot drift from the
 dashboard. All are hub only (they need a server runtime, like `server/publish.py`); local
 mode never mounts them.
 
@@ -185,23 +185,23 @@ A monitor's **watching** state gates inference
 | `idle` / `paused` / `error` | no (standby) | positively not printing |
 
 Only a *positive* "not printing" stands inference down. The watchdog loop then
-keeps the whole pipeline honest — each sustained condition warns exactly once (after a
+keeps the whole pipeline honest - each sustained condition warns exactly once (after a
 grace period, so reconnecting sources don't flap) and announces recovery:
 
 - a watched camera goes **offline**,
-- a watched camera stays online but stops producing fresh frames (**stalled** — a frozen
+- a watched camera stays online but stops producing fresh frames (**stalled** - a frozen
   RTSP feed must not pass for monitoring),
 - a linked printer service becomes **unreachable** (defects could no longer pause it).
 
 Warnings surface as dashboard toasts and go out through the notification channels.
-Notifier delivery failures and inference crashes emit `error` events — there is no
+Notifier delivery failures and inference crashes emit `error` events - there is no
 silent `except: pass` anywhere in the alert path.
 
 ## Repository layout
 
 ```
 printguard/
-  engine/            shared engine — runs on CPython and Pyodide
+  engine/            shared engine - runs on CPython and Pyodide
     registry.py      camera + printer registries (registered resources)
     monitors.py      monitor config: a camera + printer pairing and its thresholds
     printers.py      registered-printer (integration connection) validation
@@ -226,4 +226,4 @@ tests/               engine simulation + adapter contract tests (pytest)
 Local mode needs no backend at all, so the same `web/dist` build deploys to GitHub Pages:
 the release workflow zips the engine source (`printguard/pysrc.py`), copies `models/`
 into the bundle, and every asset is fetched base-relative. The mode picker probes
-`api/health` — when no hub answers, the hub card becomes a Docker self-host link.
+`api/health` - when no hub answers, the hub card becomes a Docker self-host link.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -138,7 +138,13 @@ allocation is fully dynamic:
    dispatch time. Frames carry a sequence identity, so the same frame is never inferred
    twice and results always describe the present, not a backlog.
 
-MediaMTX bursts the buffered GOP on RTSP connect, so stream fps istrusted from the SDP `average_rate`, else measured only after a warm-up.
+MediaMTX bursts the buffered GOP on RTSP connect, so stream fps is trusted from the SDP
+`average_rate`, else measured only after a warm-up.
+
+Hub camera capture is demand-driven. A source stays active while an enabled monitor is watching
+or while an HLS viewer is requesting it. MediaMTX pulls RTSP, RTMP and WHEP sources on demand;
+PrintGuard wakes its own MJPEG, Bambu and device-camera publisher for viewers. A positively idle
+printer lets the source sleep, while an unknown or unreachable printer keeps it active.
 
 ## The defect pipeline
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,15 +1,15 @@
 # Deploying a hub securely
 
-A hub exposes everything a browser needs — dashboard, engine socket, live video and
-device publishing — on a single HTTP port, `:8000`. The streaming server is built into the
+A hub exposes everything a browser needs - dashboard, engine socket, live video and
+device publishing - on a single HTTP port, `:8000`. The streaming server is built into the
 same image and listens on `:8554`/`:1935` only so LAN cameras can push streams in (its
 control API and HLS muxer bind to localhost inside the container); nothing else needs to be
 reachable. PrintGuard ships **no authentication**: anyone who can reach `:8000` sees every
-camera and can pause or cancel your printers. Never port-forward it from the internet — put
+camera and can pause or cancel your printers. Never port-forward it from the internet - put
 one of the following in front instead. Each one carries full functionality, live video
 included, because video is plain HTTP through the same port.
 
-## Option 1 — Tailscale (recommended for private hubs)
+## Option 1 - Tailscale (recommended for private hubs)
 
 Private access for you and people you invite; nothing is reachable from the public
 internet. Authentication is your tailnet identity.
@@ -18,7 +18,7 @@ internet. Authentication is your tailnet identity.
    devices, and `tailscale up` on each.
 2. Open `http://<hub-machine-name>:8000` from any device on the tailnet. Invite others
    from the Tailscale admin console if they should have access.
-3. For HTTPS — which browsers require before they allow camera access, so it is needed
+3. For HTTPS - which browsers require before they allow camera access, so it is needed
    for local mode and "this device" publishing from phones:
 
    ```bash
@@ -27,7 +27,7 @@ internet. Authentication is your tailnet identity.
 
    Then open `https://<hub-machine-name>.<tailnet>.ts.net`.
 
-## Option 2 — Cloudflare Tunnel + Access
+## Option 2 - Cloudflare Tunnel + Access
 
 A public HTTPS URL with no open ports on your network; every request (including the
 WebSockets and video) must pass a Cloudflare Access policy first.
@@ -50,9 +50,9 @@ WebSockets and video) must pass a Cloudflare Access policy first.
 4. If the host machine sits on a network you don't fully trust, also bind the local
    ports so only the tunnel can reach the app: `"127.0.0.1:8000:8000"`.
 
-## Option 3 — oauth2-proxy on your own domain
+## Option 3 - oauth2-proxy on your own domain
 
-For a hub behind a reverse proxy you manage —
+For a hub behind a reverse proxy you manage -
 [oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/) authenticates against
 GitHub/Google/any OIDC provider and proxies everything, WebSockets included, to
 PrintGuard:
@@ -81,7 +81,7 @@ PrintGuard:
 Terminate TLS in front with Caddy or nginx (or a Cloudflare Tunnel pointed at `:4180`),
 and bind PrintGuard's own port to localhost so the proxy is the only way in.
 
-The hub rejects any WebSocket whose `Origin` is not its own — the auth proxy checks the
+The hub rejects any WebSocket whose `Origin` is not its own - the auth proxy checks the
 session cookie, which the browser also attaches to sockets opened by other sites, so this
 is what stops a logged-in user's other tabs from driving the engine. It recognises the
 dashboard automatically when the proxy preserves the `Host` or sends `X-Forwarded-Host`
@@ -99,11 +99,11 @@ public origin so the hub trusts it:
 - There are no per-user roles: anyone who authenticates sees every camera and can control
   every printer. Only let in people you would hand the printer to.
 - The streaming server's control API (`:9997`) and HLS muxer (`:8888`) bind to `127.0.0.1`
-  inside the container, so they stay unreachable from outside even if a port is published —
+  inside the container, so they stay unreachable from outside even if a port is published -
   the hub talks to them over loopback and proxies HLS out through `:8000`.
 - When a proxy on the same host is the only intended client, bind ports to
   `127.0.0.1:…` in the compose file.
 - WebSocket handshakes are origin-checked, so the auth proxy is not relied on to block
   cross-site sockets. Set `PRINTGUARD_ORIGINS` only if your proxy rewrites the host header.
-- Update with `docker compose pull && docker compose up -d` — `latest` moves on every
+- Update with `docker compose pull && docker compose up -d` - `latest` moves on every
   release.

--- a/docs/printers.md
+++ b/docs/printers.md
@@ -1,24 +1,24 @@
 # Printers, cameras and notifications
 
-How to connect printers, what PrintGuard does with their webcams, how to wire up alerts —
+How to connect printers, what PrintGuard does with their webcams, how to wire up alerts -
 and the networking caveats that trip people up.
 
 ## Register a printer
 
-Register a printer — [OctoPrint](https://octoprint.org),
+Register a printer - [OctoPrint](https://octoprint.org),
 [Klipper (Moonraker)](https://moonraker.readthedocs.io),
 [Elegoo](https://github.com/ELEGOO-3D/elegoo-link),
 [Prusa (PrusaLink)](https://help.prusa3d.com/guide/wi-fi-and-prusa-connect-link-setup-core-one-mk4-s-mk3-9-mk3-5-xl-mini_413293)
-or [Bambu Lab](https://github.com/Doridian/OpenBambuAPI) — in the printer registry and test the
+or [Bambu Lab](https://github.com/Doridian/OpenBambuAPI) - in the printer registry and test the
 connection there, then bind it to a monitor. A monitor's detail panel chooses what a
 sustained defect should do: **alert only**, **pause** or **cancel**. Linked printers report
-job, progress and state on the monitors that use them — and gate inference, so an idle
+job, progress and state on the monitors that use them - and gate inference, so an idle
 printer costs you nothing.
 
 ## Printer cameras
 
 If a registered printer exposes a webcam, PrintGuard registers it as a camera automatically
-— no stream URL to copy. The camera registry's **Printer cameras** tab lists them, and a
+- no stream URL to copy. The camera registry's **Printer cameras** tab lists them, and a
 **Refresh** button picks up any camera attached to a printer after it was registered. This
 covers OctoPrint and Moonraker webcam streams, the Centauri Carbon chamber camera, and the
 Bambu chamber camera (over RTSP on the X1/H2 series, or the proprietary port-6000 protocol on
@@ -29,12 +29,12 @@ it.
 
 Beyond printer webcams, a hub takes cameras three ways:
 
-- **Stream URL** — any RTSP, RTMP, HTTP/MJPEG or WHEP source; PrintGuard creates a MediaMTX pull path.
-- **This device** — publishes a browser camera to the hub over a WebSocket. It reconnects if
+- **Stream URL** - any RTSP, RTMP, HTTP/MJPEG or WHEP source; PrintGuard creates a MediaMTX pull path.
+- **This device** - publishes a browser camera to the hub over a WebSocket. It reconnects if
   the hub restarts and resumes when you reopen the page on that device. Browsers only allow
   camera access on secure pages, so this (and local mode) needs the hub served over HTTPS or
   opened on `localhost`.
-- **Discovered** — anything already pushed to MediaMTX (e.g. `rtsp://host:8554/mycam` from a
+- **Discovered** - anything already pushed to MediaMTX (e.g. `rtsp://host:8554/mycam` from a
   Raspberry Pi) appears automatically.
 
 ## Bambu Lab
@@ -65,7 +65,7 @@ MK3.9, MK3.5, MINI, XL, CORE One) or on a Raspberry Pi attached to an MK3/MK2.5.
 authenticates with HTTP Digest, which a browser cannot perform, so Prusa is offered in **hub
 mode only**. Enable **PrusaLink** on the printer (Settings → Network → PrusaLink) and link it
 with its URL and the password shown there; the username is always `maker`. PrintGuard talks to
-PrusaLink on your network and never to Prusa's cloud — **PrusaConnect is not used**, so no
+PrusaLink on your network and never to Prusa's cloud - **PrusaConnect is not used**, so no
 frames or job data leave hardware you own. PrusaLink's webcam pushes snapshots to PrusaConnect
 rather than serving a local video stream, so if the printer has a camera, add it as a separate
 **Stream URL**.
@@ -73,7 +73,7 @@ rather than serving a local video stream, so if the printer has a camera, add it
 ## Running in Docker
 
 The hub reaches printer services from *inside the container*, so `localhost` points at the
-container, not your host — connections to `http://localhost:5000` fail with *all connection
+container, not your host - connections to `http://localhost:5000` fail with *all connection
 attempts failed*. Use `host.docker.internal` instead (e.g. `http://host.docker.internal:5000`);
 the shipped `docker-compose.yaml` maps it for you. On a Linux host the service must also
 listen on `0.0.0.0`, not just loopback.
@@ -81,12 +81,12 @@ listen on `0.0.0.0`, not just loopback.
 ## Local mode printer URLs
 
 In local mode the browser calls the services directly, so give it a URL the *browser* can
-reach — `http://localhost:5000` when it runs on the same machine, or the host's LAN IP
+reach - `http://localhost:5000` when it runs on the same machine, or the host's LAN IP
 otherwise (not `host.docker.internal`, which only resolves inside the container). The browser
 also enforces CORS: enable it in OctoPrint (Settings → API) or add `cors_domains` to
 `moonraker.conf`, otherwise the request is blocked with *access control checks* and the test
 fails. And if PrintGuard itself is served over HTTPS (e.g. a Cloudflare Tunnel), the browser
-blocks calls to an `http://` printer as mixed content — Safari reports *not allowed to request
+blocks calls to an `http://` printer as mixed content - Safari reports *not allowed to request
 resource* even for `http://localhost`. To control a local HTTP printer from an HTTPS
 deployment, use **hub mode** (the server makes the request, with no browser restrictions) or
 serve the printer over HTTPS. Telegram's API sends no CORS headers, so that channel is

--- a/printguard/__init__.py
+++ b/printguard/__init__.py
@@ -1,4 +1,4 @@
-"""PrintGuard — real-time 3D print failure detection.
+"""PrintGuard - real-time 3D print failure detection.
 
 One engine, two platforms: the same inference loop, camera and printer
 registries and monitors run on CPython (hub mode) and Pyodide (local mode).

--- a/printguard/browser/platform.py
+++ b/printguard/browser/platform.py
@@ -35,12 +35,20 @@ class BrowserSource:
         """Whether the underlying media track is still live."""
         return bool(self._bridge.isLive(self._camera_id))
 
+    @property
+    def standby(self) -> bool:
+        """Browser cameras remain live for their local preview."""
+        return False
+
     async def grab(self) -> Frame | None:
         """Draws the current video frame and converts it to RGB."""
         image_data = self._bridge.grab(self._camera_id)
         if image_data is None:
             return None
         return Frame(rgb=_imagedata_to_rgb(image_data), seq=float(image_data.seq), ts=time.time())
+
+    def set_monitoring(self, active: bool) -> None:
+        """Local previews keep their browser camera open while inference is idle."""
 
     def close(self) -> None:
         """Stops the media track."""

--- a/printguard/engine/adapters.py
+++ b/printguard/engine/adapters.py
@@ -23,12 +23,12 @@ class Adapter(ABC):
         docs_url: Link to the official API reference the adapter is built
             against; mandatory so reviewers can verify behaviour.
         browser_ok: Whether the adapter can run in local (browser) mode.
-            Adapters needing a transport the browser sandbox forbids — a
-            raw socket, or HTTP to a service without CORS headers — set
+            Adapters needing a transport the browser sandbox forbids - a
+            raw socket, or HTTP to a service without CORS headers - set
             this False and are offered in hub mode only.
         desktop_only: Whether the adapter runs only in the desktop app (the
             hub packaged as a native window), where it can reach a service the
-            headless container and the browser cannot — a local OS call. Set
+            headless container and the browser cannot - a local OS call. Set
             this True and it is offered only when the UI runs inside that app.
         experimental: Whether the adapter is new and not yet battle-tested;
             the config form flags it so users know to expect rough edges.

--- a/printguard/engine/engine.py
+++ b/printguard/engine/engine.py
@@ -57,7 +57,7 @@ class Engine:
         self.watchdog = Watchdog(self)
         self._sinks: list[Callable[[dict[str, Any]], None]] = []
         self._recent: deque[dict[str, Any]] = deque(maxlen=RECENT_EVENTS_MAX)
-        self._tasks: list[asyncio.Task] = []
+        self._tasks: list[asyncio.Task[None]] = []
         self._attach_tasks: dict[str, asyncio.Task[None]] = {}
         self._handlers: dict[str, Any] = {
             "discover": self._cmd_discover,
@@ -135,6 +135,8 @@ class Engine:
         """Cancels background loops and closes every frame source."""
         for task in self._tasks:
             task.cancel()
+        await asyncio.gather(*self._tasks, return_exceptions=True)
+        await self.watchdog.close()
         for camera_id in list(self.cameras.items):
             await self._drop_camera(camera_id)
         await asyncio.gather(*(adapter.close() for adapter in INTEGRATIONS.values()))

--- a/printguard/engine/engine.py
+++ b/printguard/engine/engine.py
@@ -333,6 +333,17 @@ class Engine:
 
         task.add_done_callback(forget)
 
+    async def restart_camera(self, camera: Camera) -> None:
+        """Releases a failed camera source and attaches it again from scratch."""
+        source = camera.frame_source
+        if source is None:
+            return
+        camera.frame_source = None
+        source.close()
+        await self.platform.release_camera(camera.id, camera.source)
+        if self.cameras.get(camera.id) is camera:
+            self._schedule_attach(camera)
+
     async def _ticker(self) -> None:
         tick = 0
         while True:

--- a/printguard/engine/engine.py
+++ b/printguard/engine/engine.py
@@ -58,6 +58,7 @@ class Engine:
         self._sinks: list[Callable[[dict[str, Any]], None]] = []
         self._recent: deque[dict[str, Any]] = deque(maxlen=RECENT_EVENTS_MAX)
         self._tasks: list[asyncio.Task] = []
+        self._attach_tasks: dict[str, asyncio.Task[None]] = {}
         self._handlers: dict[str, Any] = {
             "discover": self._cmd_discover,
             "camera.add": self._cmd_camera_add,
@@ -111,7 +112,7 @@ class Engine:
                 rotation=settings["rotation"],
             )
             self.cameras.add(camera)
-            asyncio.ensure_future(self._attach(camera))
+            self._schedule_attach(camera)
         self.cameras.sync_in_use(self.monitors, self.printers)
         self._tasks = [
             asyncio.ensure_future(self.scheduler.run()),
@@ -135,7 +136,7 @@ class Engine:
         for task in self._tasks:
             task.cancel()
         for camera_id in list(self.cameras.items):
-            self.cameras.remove(camera_id)
+            await self._drop_camera(camera_id)
         await asyncio.gather(*(adapter.close() for adapter in INTEGRATIONS.values()))
         logger.info("engine stopped")
 
@@ -310,11 +311,27 @@ class Engine:
         except Exception as exc:
             logger.debug("camera '%s' (%s) failed to attach: %s", camera.name, camera.id, exc)
             return
+        if self.cameras.get(camera.id) is not camera:
+            source.close()
+            await self.platform.release_camera(camera.id, camera.source)
+            return
         camera.frame_source = source
         source.set_monitoring(camera.in_use)
         if source.fps > 0:
             camera.max_fps = source.fps
         logger.info("camera '%s' (%s) attached at %.1f fps", camera.name, camera.id, source.fps)
+
+    def _schedule_attach(self, camera: Camera) -> None:
+        if camera.id in self._attach_tasks:
+            return
+        task = asyncio.create_task(self._attach(camera))
+        self._attach_tasks[camera.id] = task
+
+        def forget(done: asyncio.Task[None]) -> None:
+            if self._attach_tasks.get(camera.id) is done:
+                self._attach_tasks.pop(camera.id)
+
+        task.add_done_callback(forget)
 
     async def _ticker(self) -> None:
         tick = 0
@@ -324,7 +341,7 @@ class Engine:
             for camera in self.cameras.values():
                 if camera.frame_source is None:
                     if tick % REATTACH_EVERY_TICKS == 0:
-                        asyncio.ensure_future(self._attach(camera))
+                        self._schedule_attach(camera)
                 elif camera.frame_source.fps > 0:
                     camera.max_fps = camera.frame_source.fps
             self.emit(self.state_event())
@@ -434,6 +451,10 @@ class Engine:
 
     async def _drop_camera(self, camera_id: str) -> None:
         camera = self.cameras.remove(camera_id)
+        task = self._attach_tasks.pop(camera_id, None)
+        if task:
+            task.cancel()
+            await asyncio.gather(task, return_exceptions=True)
         if camera:
             await self.platform.release_camera(camera.id, camera.source)
         for monitor in self.monitors.values():

--- a/printguard/engine/engine.py
+++ b/printguard/engine/engine.py
@@ -311,6 +311,7 @@ class Engine:
             logger.debug("camera '%s' (%s) failed to attach: %s", camera.name, camera.id, exc)
             return
         camera.frame_source = source
+        source.set_monitoring(camera.in_use)
         if source.fps > 0:
             camera.max_fps = source.fps
         logger.info("camera '%s' (%s) attached at %.1f fps", camera.name, camera.id, source.fps)
@@ -397,6 +398,7 @@ class Engine:
         )
         source = await self.platform.open_camera(camera_id, camera.source)
         camera.frame_source = source
+        source.set_monitoring(camera.in_use)
         if source.fps > 0:
             camera.max_fps = source.fps
         self.cameras.add(camera)
@@ -478,6 +480,7 @@ class Engine:
                 logger.warning("printer camera '%s' failed to open: %s", descriptor["name"], exc)
                 continue
             camera.frame_source = source
+            source.set_monitoring(camera.in_use)
             if source.fps > 0:
                 camera.max_fps = source.fps
             self.cameras.add(camera)

--- a/printguard/engine/engine.py
+++ b/printguard/engine/engine.py
@@ -157,7 +157,7 @@ class Engine:
 
         Alert, warning, error and device events are also written to the log,
         so the log tail carries the same timeline a maintainer sees in a bug
-        report's recent events — plus everything around it.
+        report's recent events - plus everything around it.
         """
         level = EVENT_LOG_LEVELS.get(event.get("event", ""))
         if level is not None:
@@ -272,7 +272,7 @@ class Engine:
         """Classifies a supplied frame, returning the model's verdict and defect score.
 
         Decodes the image on the platform and runs the same inference the scheduler
-        uses — the stateless equivalent of a camera's latest per-frame result, for a
+        uses - the stateless equivalent of a camera's latest per-frame result, for a
         frame the caller already holds rather than one PrintGuard pulls itself.
         """
         rgb = await self.platform.decode_jpeg(data)

--- a/printguard/engine/integrations/__init__.py
+++ b/printguard/engine/integrations/__init__.py
@@ -3,7 +3,7 @@
 To add a service: create a module in this package with an
 IntegrationAdapter subclass and register an instance below. The
 configuration form, device polling and defect actions follow from the
-adapter alone — no other code changes are required in either mode.
+adapter alone - no other code changes are required in either mode.
 """
 
 from __future__ import annotations

--- a/printguard/engine/integrations/bambu.py
+++ b/printguard/engine/integrations/bambu.py
@@ -6,7 +6,7 @@ That needs a raw TLS socket, which the browser sandbox forbids, so this
 adapter runs in hub mode only (browser_ok is False).
 
 The user must enable LAN Only Mode and then Developer Mode on the printer
-(Settings > Network) — Developer Mode is what opens the MQTT channel on
+(Settings > Network) - Developer Mode is what opens the MQTT channel on
 current firmware. The access code is shown on that screen; the serial
 number is under Settings > Device.
 

--- a/printguard/engine/integrations/klipper.py
+++ b/printguard/engine/integrations/klipper.py
@@ -78,8 +78,8 @@ class KlipperAdapter(IntegrationAdapter):
 
         Each webcam's stream_url may be relative, resolved against the host's web
         port (see ``_resolve``); its stable uid keys the registered camera.
-        Webcams whose service advertises proprietary WebRTC signalling —
-        camera-streamer, the Crowsnest V5 default — are redirected to their
+        Webcams whose service advertises proprietary WebRTC signalling -
+        camera-streamer, the Crowsnest V5 default - are redirected to their
         MJPEG endpoint. WHEP endpoints pass through to the hub's MediaMTX client.
         """
         status, body = await http("GET", f"{config['base_url'].rstrip('/')}/server/webcams/list", headers=self._headers(config))
@@ -108,7 +108,7 @@ def _resolve(base_url: str, stream: str) -> str:
     """Resolves a webcam URL against the Moonraker host.
 
     Moonraker reports a relative path (e.g. ``/webcam/?action=stream``) as served
-    on its host's web port, not the API port carried by the base URL — its own
+    on its host's web port, not the API port carried by the base URL - its own
     documented example resolves ``/webcam/…`` to port 80. The API port (7125)
     routes no webcam paths, so a relative URL is joined to the bare host; an
     absolute URL is honoured verbatim.

--- a/printguard/engine/integrations/prusa.py
+++ b/printguard/engine/integrations/prusa.py
@@ -2,7 +2,7 @@
 
 PrusaLink runs on the printer itself (MK4, MK4S, MK3.9, MK3.5, MINI, XL, CORE
 One) or on a Raspberry Pi attached to an MK3/MK2.5. Its ``/api/v1`` API
-authenticates with HTTP Digest — username ``maker`` and the PrusaLink password
+authenticates with HTTP Digest - username ``maker`` and the PrusaLink password
 shown on the printer. 
 The client needs httpx, which the browser sandbox lacks, so it runs in hub mode only
 (``browser_ok`` is False); the printer also sends no CORS headers.
@@ -72,7 +72,7 @@ class PrusaAdapter(IntegrationAdapter):
 
         No active job (HTTP 204) is idle; any failure to reach or authenticate
         with the printer is offline, which keeps inference watching. The HTTP
-        function is unused — pyprusalink owns the digest-authenticated client.
+        function is unused - pyprusalink owns the digest-authenticated client.
         """
         try:
             job = await self._job(config)

--- a/printguard/engine/logs.py
+++ b/printguard/engine/logs.py
@@ -4,7 +4,7 @@ Modules log through the stdlib as usual; entry points call ``setup`` (or
 ``setup_from_env`` where the environment configures deployment) exactly once.
 Every record then reaches stdout for ``docker logs``, a rotating file where no
 console exists (the desktop app), and a bounded in-memory tail that bug
-reports attach — the same code on CPython and Pyodide.
+reports attach - the same code on CPython and Pyodide.
 """
 
 from __future__ import annotations
@@ -53,8 +53,8 @@ def setup(level: str = "INFO", file: Path | None = None) -> None:
     PyInstaller builds, where stdout is None) and the optional file handler,
     replacing whatever was configured before so uvicorn's loggers propagate
     here too. httpx is capped at WARNING: its per-request INFO lines flood
-    the tail, and they print full request URLs — which for Telegram embed
-    the bot token in the path — onto unscrubbed console logs.
+    the tail, and they print full request URLs - which for Telegram embed
+    the bot token in the path - onto unscrubbed console logs.
     """
     formatter = logging.Formatter(FORMAT)
     handlers: list[logging.Handler] = [tail]

--- a/printguard/engine/monitors.py
+++ b/printguard/engine/monitors.py
@@ -34,7 +34,7 @@ def monitor_watching(monitor: dict[str, Any], printers: "PrinterRegistry") -> bo
 
     A monitor is watched unless its linked printer positively reports a
     non-printing state. With no printer linked, no state polled yet, or an
-    unreachable printer the monitor stays watched — failing towards watching
+    unreachable printer the monitor stays watched - failing towards watching
     is the safe direction.
     """
     if not monitor.get("enabled"):

--- a/printguard/engine/notifiers/__init__.py
+++ b/printguard/engine/notifiers/__init__.py
@@ -2,7 +2,7 @@
 
 To add a service: create a module in this package with a NotifierAdapter
 subclass and register an instance below. The settings form, test button
-and alert delivery follow from the adapter alone — no other code changes
+and alert delivery follow from the adapter alone - no other code changes
 are required in either mode.
 """
 

--- a/printguard/engine/notifiers/native.py
+++ b/printguard/engine/notifiers/native.py
@@ -1,8 +1,8 @@
 """Native desktop notifier.
 
 Raises a notification through the operating system's own notification centre on
-the computer running the PrintGuard desktop app — Notification Center on macOS,
-a toast on Windows — via desktop-notifier, which speaks each platform's native
+the computer running the PrintGuard desktop app - Notification Center on macOS,
+a toast on Windows - via desktop-notifier, which speaks each platform's native
 API (UNUserNotificationCenter, WinRT). It reaches no external service, so it
 needs no configuration; because that native call exists only in the packaged
 desktop app, the adapter is desktop-only and is never offered by the headless
@@ -47,8 +47,8 @@ class NativeNotifier(NotifierAdapter):
     def _write_snapshot(image: bytes) -> Path:
         """Persists the snapshot where the notification can attach it as a thumbnail.
 
-        Notification centres read the attachment by path after the send returns —
-        Windows keeps a reference until the toast is drawn — so a single reused
+        Notification centres read the attachment by path after the send returns -
+        Windows keeps a reference until the toast is drawn - so a single reused
         file is overwritten rather than deleted, bounding it to one snapshot.
         """
         _SNAPSHOT_PATH.write_bytes(image)

--- a/printguard/engine/platform.py
+++ b/printguard/engine/platform.py
@@ -33,9 +33,14 @@ class FrameSource(Protocol):
 
     fps: float
     online: bool
+    standby: bool
 
     async def grab(self) -> Frame | None:
         """Returns the freshest available frame, or None if not ready."""
+        ...
+
+    def set_monitoring(self, active: bool) -> None:
+        """Starts or stops capture needed by inference."""
         ...
 
     def close(self) -> None:

--- a/printguard/engine/registry.py
+++ b/printguard/engine/registry.py
@@ -96,6 +96,11 @@ class Camera:
         """Whether the camera's frame source is attached and healthy."""
         return self.frame_source is not None and self.frame_source.online
 
+    @property
+    def standby(self) -> bool:
+        """Whether capture is intentionally sleeping until it is needed."""
+        return self.frame_source is not None and self.frame_source.standby
+
     def mark_inferred(self, result: dict[str, Any]) -> None:
         """Records a completed inference and updates the achieved rate."""
         now = time.monotonic()
@@ -118,6 +123,7 @@ class Camera:
             "inferring": self.inferring,
             "in_use": self.in_use,
             "online": self.online,
+            "standby": self.standby,
             "last_result": self.last_result,
             "brightness": round(self.brightness, 2),
             "contrast": round(self.contrast, 2),
@@ -240,6 +246,8 @@ class CameraRegistry(Registry[Camera]):
         bound = {m["camera_id"] for m in monitors.values() if monitor_watching(m, printers)}
         for camera in self.values():
             camera.in_use = camera.id in bound
+            if camera.frame_source:
+                camera.frame_source.set_monitoring(camera.in_use)
 
 
 class PrinterRegistry(Registry[Printer]):

--- a/printguard/engine/registry.py
+++ b/printguard/engine/registry.py
@@ -1,4 +1,4 @@
-"""Resource registries — cameras, integrated printers and API tokens — each an
+"""Resource registries - cameras, integrated printers and API tokens - each an
 id-keyed collection of records carrying identity, access details and any live
 runtime state."""
 
@@ -58,7 +58,7 @@ class Camera:
         id: Stable identifier used across the protocol and as the MediaMTX
             path name in hub mode.
         name: Display name.
-        source: Access details — {"kind": "device", "device_id": ...} in
+        source: Access details - {"kind": "device", "device_id": ...} in
             local mode, {"kind": "url" | "path", ...} in hub mode.
         printer_id: Owning printer when the camera was exposed by a printer
             integration, else None. Such cameras are managed by their printer:
@@ -197,7 +197,7 @@ class Token:
     Attributes:
         id: Stable identifier used to name and revoke the token.
         name: Display name.
-        scope: Granted capability — one of read, control or manage.
+        scope: Granted capability - one of read, control or manage.
         hash: SHA-256 of the bearer secret, matched at auth time.
         hint: Short non-secret prefix shown in the UI.
         created: Unix timestamp the token was minted.

--- a/printguard/engine/reports.py
+++ b/printguard/engine/reports.py
@@ -1,11 +1,11 @@
 """Sends anonymous bug reports to the project's Sentry feedback inbox.
 
-A report is a single user-initiated POST of a Sentry envelope — a feedback
+A report is a single user-initiated POST of a Sentry envelope - a feedback
 item carrying the user's description and optional contact email, plus a
 sanitised diagnostics bundle, the engine and UI log tails and any files the
 user attached. There is no SDK and no automatic telemetry: nothing leaves
 the device unless the user submits a report, and every credential is
-stripped before it does — structurally from the diagnostics, and by value
+stripped before it does - structurally from the diagnostics, and by value
 from the freeform log text, where a library error message may embed one.
 """
 

--- a/printguard/engine/updates.py
+++ b/printguard/engine/updates.py
@@ -32,7 +32,7 @@ async def fetch_updates(http: HttpFn, repo: str, current: str, asset: str | None
     Returns:
         A status dict with ``current``, ``latest``, ``available``, the
         ``releases`` newer than ``current`` (newest first, each carrying its
-        changelog ``notes`` and ``url``) and ``download`` — the latest
+        changelog ``notes`` and ``url``) and ``download`` - the latest
         release's URL for ``asset``, or None.
 
     Raises:

--- a/printguard/engine/watchdog.py
+++ b/printguard/engine/watchdog.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Coroutine
 
 from .integrations import INTEGRATIONS, DeviceAction
 from .monitors import monitor_watching
@@ -44,6 +44,19 @@ class Watchdog:
         self._down_since: dict[str, float] = {}
         self._warned: set[str] = set()
         self._online_since: dict[str, float] = {}
+        self._tasks: set[asyncio.Task[None]] = set()
+
+    def _schedule(self, coroutine: Coroutine[Any, Any, None]) -> None:
+        task = asyncio.create_task(coroutine)
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+
+    async def close(self) -> None:
+        """Cancels pending printer actions and notifications."""
+        tasks = tuple(self._tasks)
+        for task in tasks:
+            task.cancel()
+        await asyncio.gather(*tasks, return_exceptions=True)
 
     async def poll_devices(self) -> None:
         """Periodically refreshes registered printer states.
@@ -105,9 +118,14 @@ class Watchdog:
                 )
                 if offline:
                     await self._engine.restart_camera(camera)
-                progressing = not camera.online or now - max(camera.last_done, self._online_since.get(mid, now)) < STALL_GRACE_S
-                await self._edge(
-                    f"stalled:{mid}",
+                stall_key = f"stalled:{mid}"
+                progressing = (
+                    camera.online and camera.last_done > self._down_since[stall_key]
+                    if stall_key in self._warned
+                    else not camera.online or now - max(camera.last_done, self._online_since.get(mid, now)) < STALL_GRACE_S
+                )
+                stalled = await self._edge(
+                    stall_key,
                     progressing,
                     now,
                     0.0,
@@ -115,6 +133,8 @@ class Watchdog:
                     f"Camera '{camera.name}' feed has stalled — '{monitor['name']}' is NOT being monitored",
                     f"Camera '{camera.name}' feed recovered — '{monitor['name']}' is monitored again",
                 )
+                if stalled:
+                    await self._engine.restart_camera(camera)
                 printer = self._engine.printers.get(monitor["printer_id"]) if monitor.get("printer_id") else None
                 if printer is not None:
                     reachable = (printer.device_state or {}).get("status") != "offline"
@@ -155,7 +175,7 @@ class Watchdog:
     async def _warn(self, monitor: dict[str, Any], message: str, recovered: bool = False) -> None:
         self._engine.emit({"event": "warning", "monitor_id": monitor["id"], "message": message, "recovered": recovered})
         if monitor.get("notify"):
-            await self._send_alerts(f"PrintGuard {'recovered' if recovered else 'warning'}", message, None)
+            self._schedule(self._send_alerts(f"PrintGuard {'recovered' if recovered else 'warning'}", message, None))
 
     async def on_score(self, monitor: dict[str, Any], frame: Frame, score: float) -> None:
         """Advances the defect streak for a monitor and triggers responses.
@@ -175,11 +195,16 @@ class Watchdog:
         if self._streaks[mid] < monitor["consecutive"] or time.monotonic() < self._cooldown_until.get(mid, 0.0):
             return
         self._cooldown_until[mid] = time.monotonic() + monitor["cooldown_s"]
+        self._schedule(self._respond(monitor, frame, score))
+
+    async def _respond(self, monitor: dict[str, Any], frame: Frame, score: float) -> None:
         action = await self._act(monitor)
-        monitor["alert"] = {"score": round(score, 3), "action": action, "ts": time.time()}
-        self._engine.emit({"event": "alert", "monitor_id": mid, **monitor["alert"]})
+        alert = {"score": round(score, 3), "action": action, "ts": time.time()}
+        if self._streaks.get(monitor["id"], 0):
+            monitor["alert"] = alert
+        self._engine.emit({"event": "alert", "monitor_id": monitor["id"], **alert})
         image = await self._engine.platform.encode_jpeg(frame.rgb)
-        self._engine.note_alert(mid, monitor["alert"], image)
+        self._engine.note_alert(monitor["id"], alert, image)
         await self._notify(monitor, score, action, image)
 
     async def _act(self, monitor: dict[str, Any]) -> str:

--- a/printguard/engine/watchdog.py
+++ b/printguard/engine/watchdog.py
@@ -92,7 +92,7 @@ class Watchdog:
         Outages shorter than the grace period are ignored so reconnecting
         sources do not flap; each sustained outage warns exactly once and
         announces its recovery. A camera that stays online but stops
-        producing fresh frames counts as stalled — frozen feeds must not
+        producing fresh frames counts as stalled - frozen feeds must not
         pass for monitoring.
         """
         while True:

--- a/printguard/engine/watchdog.py
+++ b/printguard/engine/watchdog.py
@@ -94,7 +94,7 @@ class Watchdog:
                     self._online_since.setdefault(mid, now)
                 else:
                     self._online_since.pop(mid, None)
-                await self._edge(
+                offline = await self._edge(
                     f"offline:{mid}",
                     camera.online,
                     now,
@@ -103,6 +103,8 @@ class Watchdog:
                     f"Camera '{camera.name}' is offline — '{monitor['name']}' is NOT being monitored",
                     f"Camera '{camera.name}' is back — '{monitor['name']}' is monitored again",
                 )
+                if offline:
+                    await self._engine.restart_camera(camera)
                 progressing = not camera.online or now - max(camera.last_done, self._online_since.get(mid, now)) < STALL_GRACE_S
                 await self._edge(
                     f"stalled:{mid}",
@@ -136,17 +138,19 @@ class Watchdog:
         monitor: dict[str, Any],
         down_message: str,
         up_message: str,
-    ) -> None:
+    ) -> bool:
         if healthy:
             self._down_since.pop(key, None)
             if key in self._warned:
                 self._warned.discard(key)
                 await self._warn(monitor, up_message, recovered=True)
-            return
+            return False
         since = self._down_since.setdefault(key, now)
         if now - since >= grace and key not in self._warned:
             self._warned.add(key)
             await self._warn(monitor, down_message)
+            return True
+        return False
 
     async def _warn(self, monitor: dict[str, Any], message: str, recovered: bool = False) -> None:
         self._engine.emit({"event": "warning", "monitor_id": monitor["id"], "message": message, "recovered": recovered})

--- a/printguard/engine/watchdog.py
+++ b/printguard/engine/watchdog.py
@@ -211,7 +211,7 @@ class Watchdog:
         if action == "failed":
             body = f"AUTOMATIC {monitor['on_defect'].upper()} FAILED — check the printer"
         elif action == "none":
-            body = "No automatic action configured"
+            body = "Alert only: no printer action configured"
         else:
             body = f"Action taken: {action}"
         await self._send_alerts(title, body, image)

--- a/printguard/server/api.py
+++ b/printguard/server/api.py
@@ -232,7 +232,7 @@ def public_state(engine: Engine) -> dict[str, Any]:
     """The engine snapshot with linked-service credentials stripped.
 
     The dashboard reads the engine's full state over the WebSocket, where trust
-    is total; this read surface — REST and the MCP tools derived from it — must
+    is total; this read surface - REST and the MCP tools derived from it - must
     report status without leaking the printer and notifier credentials those
     configs embed, nor the access codes a printer-exposed camera source carries.
     Redaction reuses the secret fields each adapter's schema already declares
@@ -397,7 +397,7 @@ def build_api_app(auth: ApiAuth) -> FastAPI:
         sensitivity: float = 1.0,
         engine: Engine = Depends(get_engine),
     ) -> dict[str, Any]:
-        """Classifies a supplied JPEG frame — the model's verdict without a registered camera."""
+        """Classifies a supplied JPEG frame - the model's verdict without a registered camera."""
         return await engine.classify(image, sensitivity)
 
     @api.post("/cameras", operation_id="add_camera", tags=["manage"], response_model=list[CameraOut])

--- a/printguard/server/api.py
+++ b/printguard/server/api.py
@@ -160,6 +160,7 @@ class CameraOut(_ReadModel):
     inferring: bool | None = None
     in_use: bool | None = None
     online: bool | None = None
+    standby: bool | None = None
     last_result: LastResult | None = None
     brightness: float | None = None
     contrast: float | None = None

--- a/printguard/server/app.py
+++ b/printguard/server/app.py
@@ -1,6 +1,6 @@
 """FastAPI application: serves the UI, model assets and the engine socket.
 
-The same image serves both modes — hub mode runs the engine here, while
+The same image serves both modes - hub mode runs the engine here, while
 local mode only needs the static UI, the model files and the Python
 source archive that Pyodide unpacks in the browser.
 """
@@ -171,7 +171,7 @@ def create_app() -> FastAPI:
     async def hls_proxy(path: str, request: Request) -> StreamingResponse:
         """Streams LL-HLS playlists and segments from MediaMTX through the hub's own port.
 
-        An unreachable MediaMTX answers 502 with a throttled warning — the
+        An unreachable MediaMTX answers 502 with a throttled warning - the
         dashboard polls playlists every second, so letting the error escape
         would flood the log with one ASGI traceback per poll.
         """
@@ -234,7 +234,7 @@ def main() -> None:
     """Console entry point.
 
     Uvicorn runs without its own logging config so its records propagate to
-    the root handlers, and without access logs — per-request lines for the
+    the root handlers, and without access logs - per-request lines for the
     HLS polling would drown the tail that bug reports attach.
     """
     uvicorn.run(create_app(), host="0.0.0.0", port=int(os.environ.get("PORT", "8000")), log_config=None, access_log=False)

--- a/printguard/server/app.py
+++ b/printguard/server/app.py
@@ -175,6 +175,7 @@ def create_app() -> FastAPI:
         dashboard polls playlists every second, so letting the error escape
         would flood the log with one ASGI traceback per poll.
         """
+        await platform.view_camera(path.split("/", 1)[0])
         client: httpx.AsyncClient = app.state.hls
         try:
             upstream = await client.send(

--- a/printguard/server/app.py
+++ b/printguard/server/app.py
@@ -175,7 +175,7 @@ def create_app() -> FastAPI:
         dashboard polls playlists every second, so letting the error escape
         would flood the log with one ASGI traceback per poll.
         """
-        await platform.view_camera(path.split("/", 1)[0])
+        await app.state.engine.platform.view_camera(path.split("/", 1)[0])
         client: httpx.AsyncClient = app.state.hls
         try:
             upstream = await client.send(

--- a/printguard/server/desktop.py
+++ b/printguard/server/desktop.py
@@ -84,8 +84,8 @@ def _set_windows_app_id() -> None:
 
     Windows groups a program's taskbar entry and its toast notifications by AppUserModelID;
     a frozen Python process has none of its own, so the desktop notifier's toasts would appear
-    under a generic identity. Pinning it to the app name — the same id desktop-notifier registers
-    the app icon against — gives those toasts PrintGuard's name and icon.
+    under a generic identity. Pinning it to the app name - the same id desktop-notifier registers
+    the app icon against - gives those toasts PrintGuard's name and icon.
     """
     if sys.platform != "win32":
         return
@@ -128,7 +128,7 @@ def _run_webview(url: str) -> None:
 
     The window owns its process's main thread, so it never contends with the
     tray's, and closing it ends only this process. The webview must keep its
-    website data between windows — pywebview's default private mode erases
+    website data between windows - pywebview's default private mode erases
     localStorage on every launch (on macOS it wipes the whole store), which
     would lose the page's record of which "this device" cameras it publishes,
     so a reopened window would never resume them.

--- a/printguard/server/mcp.py
+++ b/printguard/server/mcp.py
@@ -83,7 +83,7 @@ def build_mcp(
 
     @mcp.tool(name="classify_frame", tags={"read"})
     async def classify_frame(image_base64: str, sensitivity: float = 1.0) -> dict:
-        """Classifies a supplied print image for defects — no registered camera needed.
+        """Classifies a supplied print image for defects - no registered camera needed.
 
         Pass a base64-encoded JPEG or PNG frame (one shared in the conversation or
         downloaded) and get back {prediction, distances, margin, defect_score}: the

--- a/printguard/server/mediamtx.py
+++ b/printguard/server/mediamtx.py
@@ -58,7 +58,12 @@ class MediaMTX:
         A fingerprint is the SHA-256 of a self-signed source certificate (hex,
         no colons), letting MediaMTX validate an otherwise-untrusted RTSPS feed.
         """
-        payload: dict[str, Any] = {"source": source_url, "sourceOnDemand": False}
+        payload: dict[str, Any] = {
+            "source": source_url,
+            "sourceOnDemand": True,
+            "sourceOnDemandStartTimeout": "30s",
+            "sourceOnDemandCloseAfter": "10s",
+        }
         if fingerprint:
             payload["sourceFingerprint"] = fingerprint
         resp = await self._client.post(f"{self._api}/v3/config/paths/add/{name}", json=payload, timeout=5.0)

--- a/printguard/server/mqtt.py
+++ b/printguard/server/mqtt.py
@@ -5,7 +5,7 @@ surface that owns no monitoring logic of its own. It reconciles one Home
 Assistant device per monitor through MQTT *device-based* discovery, publishes
 each monitor's state and failure snapshot, and routes inbound Home Assistant
 commands (the Enabled switch and the printer Pause/Resume/Cancel buttons) back
-through ``engine.request()`` — so PrintGuard appears as a first-class,
+through ``engine.request()`` - so PrintGuard appears as a first-class,
 controllable device in Home Assistant without the engine knowing MQTT exists.
 
 Connection settings live in engine settings under ``mqtt`` and are edited from

--- a/printguard/server/platform.py
+++ b/printguard/server/platform.py
@@ -56,7 +56,7 @@ def _video_devices() -> list[tuple[str, str]]:
 
     libavdevice only exposes device discovery through its log stream, so the
     names are parsed from a capture of the listing call's messages, raised to
-    INFO for the duration. Screens are excluded — a capture of the host's own
+    INFO for the duration. Screens are excluded - a capture of the host's own
     display is never a printer camera. Listing needs no camera permission;
     only opening a device does.
     """
@@ -112,8 +112,8 @@ def _device_open_options(device_id: str) -> tuple[dict[str, str], ...]:
     """Capture options to try when opening a device, most specific first.
 
     ffmpeg's avfoundation ignores the requested frame rate when no size is given
-    and settles on the device's last-listed format — routinely its top
-    resolution pinned to a handful of fps — so 30/15fps requests come back as
+    and settles on the device's last-listed format - routinely its top
+    resolution pinned to a handful of fps - so 30/15fps requests come back as
     EAGAIN. On macOS the real formats are read from AVFoundation and the largest
     size within a sane cap that offers a usable rate is pinned explicitly; other
     platforms negotiate over common frame rates.
@@ -169,8 +169,8 @@ def _authorize_macos_camera() -> None:
     is undetermined starts a session that delivers no frames, and once refused
     the capture input fails instantly with EAGAIN. So consent is settled through
     AVFoundation first, blocking until the user answers. A grant recorded for a
-    previous build still reads as authorised while capture is refused — each
-    unsigned build re-signs ad hoc with a new identity — so an authorised state
+    previous build still reads as authorised while capture is refused - each
+    unsigned build re-signs ad hoc with a new identity - so an authorised state
     is probed with a real capture input, and a refusal resets this app's own
     consent entry to let the prompt be asked afresh. Other platforms gate
     camera capture without a per-process consent step.
@@ -332,7 +332,7 @@ class AVSource:
         """Keeps the freshest frame until the source ends, transcoding if asked.
 
         A capture device announces its stream before a frame is buffered, so the
-        first reads — and any gap between frames — surface as EAGAIN. That is not
+        first reads - and any gap between frames - surface as EAGAIN. That is not
         a disconnect: the open session is kept and the read retried, rather than
         torn down and reconnected as a network drop would be.
         """
@@ -442,13 +442,13 @@ class ServerPlatform:
         RTSP/RTMP URLs and WebRTC WHEP endpoints are pulled by MediaMTX;
         HTTP/MJPEG ones are read directly and transcoded back into MediaMTX so
         both inference and viewers see them. Device sources are the host's own
-        cameras, captured through libavdevice in this process — not a browser
-        page — so on the desktop app they keep watching with every window closed;
+        cameras, captured through libavdevice in this process - not a browser
+        page - so on the desktop app they keep watching with every window closed;
         they are republished the same way.
 
         The wait must outlast a freshly published path's cold start: the remux
         announcing the track, a not-found retry, the demuxer probe, a mid-GOP
-        join and — when the container declares no rate — measuring the fps.
+        join and - when the container declares no rate - measuring the fps.
         Together those approach twenty seconds; sources that are truly dead
         just take this long to report.
         """

--- a/printguard/server/platform.py
+++ b/printguard/server/platform.py
@@ -35,6 +35,7 @@ MEASURE_WARMUP_S = 1.0
 OPEN_WAIT_S = 25.0
 CAMERA_CONSENT_WAIT_S = 60.0
 RECONNECT_DELAY_S = 3.0
+VIEWER_IDLE_S = 10.0
 MJPEG_LIVE_OPTIONS = {"analyzeduration": "0", "probesize": "32"}
 DEVICE_OPEN_OPTIONS = ({"framerate": "30"}, {"framerate": "15"}, {})
 """Frame rates tried, most common first, when a device's own capture formats
@@ -237,8 +238,33 @@ class AVSource:
         self._latest: Frame | None = None
         self._seq = 0
         self._stop = False
+        self._monitoring = True
+        self._viewer_until = 0.0
+        self._wake = threading.Event()
+        self._wake.set()
         self._thread = threading.Thread(target=self._run, daemon=True)
         self._thread.start()
+
+    @property
+    def standby(self) -> bool:
+        """Whether capture is sleeping until inference or a viewer needs it."""
+        return not self._demanded()
+
+    def _demanded(self) -> bool:
+        return self._monitoring or time.monotonic() < self._viewer_until
+
+    def set_monitoring(self, active: bool) -> None:
+        """Keeps capture running while inference needs frames."""
+        self._monitoring = active
+        self._wake.set()
+
+    def view(self) -> bool:
+        """Keeps direct-source publishing alive for a recent HLS viewer."""
+        if self._publish_url is None:
+            return False
+        self._viewer_until = time.monotonic() + VIEWER_IDLE_S
+        self._wake.set()
+        return True
 
     def _open(self) -> tuple[Any, Any]:
         """Opens the container, returning it and any pipe to close afterwards.
@@ -267,6 +293,11 @@ class AVSource:
 
     def _run(self) -> None:
         while not self._stop:
+            if not self._demanded():
+                self.online = False
+                self._wake.wait()
+                self._wake.clear()
+                continue
             container: Any = None
             push: H264Push | None = None
             pipe: Any = None
@@ -291,7 +322,7 @@ class AVSource:
                 if pipe is not None:
                     pipe.close()
             self.online = False
-            if not self._stop:
+            if not self._stop and self._demanded():
                 time.sleep(RECONNECT_DELAY_S)
 
     def _decode(self, container: Any, stream: Any, push: H264Push | None) -> None:
@@ -307,7 +338,7 @@ class AVSource:
         while not self._stop:
             try:
                 for frame in container.decode(stream):
-                    if self._stop:
+                    if self._stop or not self._demanded():
                         return
                     self._seq += 1
                     self._latest = Frame(rgb=frame.to_ndarray(format="rgb24"), seq=float(self._seq), ts=time.time())
@@ -330,6 +361,7 @@ class AVSource:
         """Stops the reader thread."""
         self._stop = True
         self.online = False
+        self._wake.set()
 
 
 class ServerPlatform:
@@ -354,6 +386,7 @@ class ServerPlatform:
         data_dir.mkdir(parents=True, exist_ok=True)
         self._client = httpx.AsyncClient(follow_redirects=True)
         self.mediamtx = MediaMTX(mediamtx_api, mediamtx_rtsp, self._client)
+        self._sources: dict[str, AVSource] = {}
 
     async def close(self) -> None:
         """Releases the HTTP client and inference workers."""
@@ -431,6 +464,7 @@ class ServerPlatform:
         else:
             raise ValueError(f"hub mode cannot open source kind {source['kind']!r}")
         av_source = AVSource(target, publish_url, container_format, open_options)
+        self._sources[camera_id] = av_source
         deadline = time.monotonic() + OPEN_WAIT_S
         while time.monotonic() < deadline and not (av_source.online and av_source.fps > 0):
             await asyncio.sleep(0.2)
@@ -441,8 +475,18 @@ class ServerPlatform:
             raise RuntimeError(f"no frames from camera {camera_id}{detail}")
         return av_source
 
+    async def view_camera(self, camera_id: str) -> None:
+        """Wakes a direct camera source for an HLS request."""
+        source = self._sources.get(camera_id)
+        if not source or not source.view():
+            return
+        deadline = time.monotonic() + OPEN_WAIT_S
+        while time.monotonic() < deadline and not source.online:
+            await asyncio.sleep(0.1)
+
     async def release_camera(self, camera_id: str, source: dict[str, Any]) -> None:
         """Removes the MediaMTX path created for a URL-backed camera."""
+        self._sources.pop(camera_id, None)
         if source["kind"] == "url" and pull_source(source["url"]) is not None:
             try:
                 await self.mediamtx.remove_path(camera_id)

--- a/printguard/server/platform.py
+++ b/printguard/server/platform.py
@@ -235,7 +235,8 @@ class AVSource:
         self.fps = 0.0
         self.online = False
         self.last_error: str | None = None
-        self._latest: Frame | None = None
+        self._latest: tuple[av.VideoFrame, float, float] | None = None
+        self._latest_rgb: Frame | None = None
         self._seq = 0
         self._stop = False
         self._monitoring = True
@@ -341,7 +342,7 @@ class AVSource:
                     if self._stop or not self._demanded():
                         return
                     self._seq += 1
-                    self._latest = Frame(rgb=frame.to_ndarray(format="rgb24"), seq=float(self._seq), ts=time.time())
+                    self._latest = (frame, float(self._seq), time.time())
                     self.online = True
                     if push is not None:
                         push.send(frame)
@@ -354,8 +355,18 @@ class AVSource:
                 time.sleep(0.02)
 
     async def grab(self) -> Frame | None:
-        """Returns the freshest decoded frame without copying."""
-        return self._latest
+        """Converts and returns the freshest decoded frame."""
+        latest = self._latest
+        if latest is None:
+            return None
+        frame, seq, ts = latest
+        if self._latest_rgb is not None and self._latest_rgb.seq == seq:
+            return self._latest_rgb
+        rgb = await asyncio.to_thread(frame.to_ndarray, format="rgb24")
+        result = Frame(rgb=rgb, seq=seq, ts=ts)
+        if self._latest is latest:
+            self._latest_rgb = result
+        return result
 
     def close(self) -> None:
         """Stops the reader thread."""

--- a/printguard/server/platform.py
+++ b/printguard/server/platform.py
@@ -35,7 +35,7 @@ MEASURE_WARMUP_S = 1.0
 OPEN_WAIT_S = 25.0
 CAMERA_CONSENT_WAIT_S = 60.0
 RECONNECT_DELAY_S = 3.0
-VIEWER_IDLE_S = 10.0
+DEMAND_IDLE_S = 10.0
 MJPEG_LIVE_OPTIONS = {"analyzeduration": "0", "probesize": "32"}
 DEVICE_OPEN_OPTIONS = ({"framerate": "30"}, {"framerate": "15"}, {})
 """Frame rates tried, most common first, when a device's own capture formats
@@ -240,7 +240,7 @@ class AVSource:
         self._seq = 0
         self._stop = False
         self._monitoring = True
-        self._viewer_until = 0.0
+        self._demand_until = 0.0
         self._wake = threading.Event()
         self._wake.set()
         self._thread = threading.Thread(target=self._run, daemon=True)
@@ -252,10 +252,12 @@ class AVSource:
         return not self._demanded()
 
     def _demanded(self) -> bool:
-        return self._monitoring or time.monotonic() < self._viewer_until
+        return self._monitoring or time.monotonic() < self._demand_until
 
     def set_monitoring(self, active: bool) -> None:
         """Keeps capture running while inference needs frames."""
+        if self._monitoring and not active:
+            self._demand_until = max(self._demand_until, time.monotonic() + DEMAND_IDLE_S)
         self._monitoring = active
         self._wake.set()
 
@@ -263,7 +265,7 @@ class AVSource:
         """Keeps direct-source publishing alive for a recent HLS viewer."""
         if self._publish_url is None:
             return False
-        self._viewer_until = time.monotonic() + VIEWER_IDLE_S
+        self._demand_until = time.monotonic() + DEMAND_IDLE_S
         self._wake.set()
         return True
 
@@ -494,6 +496,7 @@ class ServerPlatform:
         deadline = time.monotonic() + OPEN_WAIT_S
         while time.monotonic() < deadline and not source.online:
             await asyncio.sleep(0.1)
+        source.view()
 
     async def release_camera(self, camera_id: str, source: dict[str, Any]) -> None:
         """Removes the MediaMTX path created for a URL-backed camera."""

--- a/printguard/server/platform.py
+++ b/printguard/server/platform.py
@@ -478,11 +478,17 @@ class ServerPlatform:
             raise ValueError(f"hub mode cannot open source kind {source['kind']!r}")
         av_source = AVSource(target, publish_url, container_format, open_options)
         self._sources[camera_id] = av_source
-        deadline = time.monotonic() + OPEN_WAIT_S
-        while time.monotonic() < deadline and not (av_source.online and av_source.fps > 0):
-            await asyncio.sleep(0.2)
+        try:
+            deadline = time.monotonic() + OPEN_WAIT_S
+            while time.monotonic() < deadline and not (av_source.online and av_source.fps > 0):
+                await asyncio.sleep(0.2)
+        except asyncio.CancelledError:
+            if self._sources.get(camera_id) is av_source:
+                await self.release_camera(camera_id, source)
+            else:
+                av_source.close()
+            raise
         if not av_source.online:
-            av_source.close()
             await self.release_camera(camera_id, source)
             detail = f": {av_source.last_error}" if av_source.last_error else ""
             raise RuntimeError(f"no frames from camera {camera_id}{detail}")
@@ -499,8 +505,10 @@ class ServerPlatform:
         source.view()
 
     async def release_camera(self, camera_id: str, source: dict[str, Any]) -> None:
-        """Removes the MediaMTX path created for a URL-backed camera."""
-        self._sources.pop(camera_id, None)
+        """Closes the source and removes any MediaMTX pull path."""
+        av_source = self._sources.pop(camera_id, None)
+        if av_source:
+            av_source.close()
         if source["kind"] == "url" and pull_source(source["url"]) is not None:
             try:
                 await self.mediamtx.remove_path(camera_id)

--- a/printguard/server/publish.py
+++ b/printguard/server/publish.py
@@ -1,7 +1,7 @@
 """Pushes camera video to MediaMTX over RTSP.
 
-Browser recordings (fragmented WebM/MP4 over a WebSocket) are remuxed — never
-transcoded — by remux(). Sources MediaMTX cannot pull itself, such as MJPEG
+Browser recordings (fragmented WebM/MP4 over a WebSocket) are remuxed - never
+transcoded - by remux(). Sources MediaMTX cannot pull itself, such as MJPEG
 over HTTP, are transcoded to H.264 by H264Push. Either way the result behaves
 like any other MediaMTX stream and reaches viewers as HLS.
 """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "printguard"
-version = "2.3.5"
+version = "2.3.6"
 description = "Real-time 3D print failure detection"
 
 license = "GPL-2.0-only"

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -18,12 +18,17 @@ class FakeSource:
     def __init__(self, fps: float) -> None:
         self.fps = fps
         self.online = True
+        self.standby = False
         self._born = time.monotonic()
 
     async def grab(self) -> Frame | None:
         seq = int((time.monotonic() - self._born) * self.fps)
         rgb = np.full((48, 64, 3), seq % 255, dtype=np.uint8)
         return Frame(rgb=rgb, seq=float(seq), ts=time.time())
+
+    def set_monitoring(self, active: bool) -> None:
+        self.standby = not active
+        self.online = active
 
     def close(self) -> None:
         self.online = False

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -19,10 +19,11 @@ class FakeSource:
         self.fps = fps
         self.online = True
         self.standby = False
+        self.frozen = False
         self._born = time.monotonic()
 
     async def grab(self) -> Frame | None:
-        seq = int((time.monotonic() - self._born) * self.fps)
+        seq = 0 if self.frozen else int((time.monotonic() - self._born) * self.fps)
         rgb = np.full((48, 64, 3), seq % 255, dtype=np.uint8)
         return Frame(rgb=rgb, seq=float(seq), ts=time.time())
 
@@ -48,6 +49,8 @@ class FakePlatform:
         self.failing = failing
         self.device_status = "Printing"
         self.reject_actions = False
+        self.action_delay_s = 0.0
+        self.action_started = asyncio.Event()
         self.report_status = 200
         self.http_calls: list[tuple[str, str]] = []
         self.http_requests: list[dict[str, Any]] = []
@@ -77,6 +80,9 @@ class FakePlatform:
             return 200, self.releases
         if hostname == "sentry.io" or hostname.endswith(".sentry.io"):
             return self.report_status, {}
+        if method == "POST" and "/api/job" in url:
+            self.action_started.set()
+            await asyncio.sleep(self.action_delay_s)
         if self.reject_actions and method == "POST" and "/api/job" in url:
             raise RuntimeError("printer refused")
         return 200, {"state": self.device_status, "progress": {"completion": 40.0}, "job": {"file": {"name": "benchy.gcode"}}}

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -52,6 +52,7 @@ class FakePlatform:
         self.http_calls: list[tuple[str, str]] = []
         self.http_requests: list[dict[str, Any]] = []
         self.releases: list[dict[str, Any]] = []
+        self.released_cameras: list[str] = []
         self.state: dict[str, Any] = {}
 
     async def infer(self, rgb: np.ndarray) -> dict[str, Any]:
@@ -66,7 +67,7 @@ class FakePlatform:
         return FakeSource(float(source.get("fps", 15.0)))
 
     async def release_camera(self, camera_id: str, source: dict[str, Any]) -> None:
-        pass
+        self.released_cameras.append(camera_id)
 
     async def http(self, method: str, url: str, **kwargs: Any) -> tuple[int, Any]:
         self.http_calls.append((method, url))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -224,6 +224,29 @@ def test_callable_mjpeg_sources_cap_pyav_probe(monkeypatch) -> None:
     }, "live MJPEG pipes cap PyAV probing so av.open returns instead of draining frames"
 
 
+def test_direct_camera_source_wakes_for_viewers(monkeypatch) -> None:
+    from printguard.server import platform
+
+    monkeypatch.setattr(platform.threading.Thread, "start", lambda self: None)
+    source = platform.AVSource("http://camera/stream", "rtsp://mediamtx/camera")
+    source.set_monitoring(False)
+    assert source.standby
+    source.view()
+    assert not source.standby
+    source.close()
+
+
+def test_pullable_camera_source_leaves_viewing_to_mediamtx(monkeypatch) -> None:
+    from printguard.server import platform
+
+    monkeypatch.setattr(platform.threading.Thread, "start", lambda self: None)
+    source = platform.AVSource("rtsp://mediamtx/camera")
+    source.set_monitoring(False)
+    source.view()
+    assert source.standby
+    source.close()
+
+
 async def test_unknown_ids_and_events() -> None:
     async with api() as (client, _engine, _platform, _monitor_id, _printer_id, _camera_id, _tokens):
         assert (await client.get("/printers/nope")).status_code == 404

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
 from unittest.mock import Mock
@@ -267,6 +268,25 @@ async def test_view_camera_renews_demand_after_cold_start() -> None:
     await server.view_camera("camera")
 
     assert source.view.call_count == 2
+
+
+async def test_cancelled_camera_open_closes_platform_source(monkeypatch) -> None:
+    from printguard.server import platform
+
+    source = SimpleNamespace(online=False, fps=0.0, last_error=None, close=Mock())
+    monkeypatch.setattr(platform, "AVSource", lambda *args: source)
+    server = object.__new__(platform.ServerPlatform)
+    server.mediamtx = SimpleNamespace(rtsp_url=Mock(return_value="rtsp://mediamtx/camera"))
+    server._sources = {}
+    task = asyncio.create_task(server.open_camera("camera", {"kind": "url", "url": "http://camera/stream"}))
+    await asyncio.sleep(0)
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    source.close.assert_called_once()
+    assert server._sources == {}
 
 
 async def test_camera_source_converts_only_grabbed_frames(monkeypatch) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -247,6 +247,31 @@ def test_pullable_camera_source_leaves_viewing_to_mediamtx(monkeypatch) -> None:
     source.close()
 
 
+async def test_camera_source_converts_only_grabbed_frames(monkeypatch) -> None:
+    from printguard.server import platform
+
+    monkeypatch.setattr(platform.threading.Thread, "start", lambda self: None)
+
+    class VideoFrame:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def to_ndarray(self, *, format: str):
+            self.calls += 1
+            return np.zeros((48, 64, 3), dtype=np.uint8)
+
+    frame = VideoFrame()
+    source = platform.AVSource("rtsp://mediamtx/camera")
+    source._latest = (frame, 1.0, 2.0)
+    first = await source.grab()
+    second = await source.grab()
+    source.close()
+
+    assert first is second
+    assert first is not None and first.seq == 1.0 and first.ts == 2.0
+    assert frame.calls == 1
+
+
 async def test_unknown_ids_and_events() -> None:
     async with api() as (client, _engine, _platform, _monitor_id, _printer_id, _camera_id, _tokens):
         assert (await client.get("/printers/nope")).status_code == 404

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from contextlib import asynccontextmanager
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import httpx
 import numpy as np
@@ -287,6 +287,20 @@ async def test_cancelled_camera_open_closes_platform_source(monkeypatch) -> None
 
     source.close.assert_called_once()
     assert server._sources == {}
+
+
+async def test_releasing_pull_camera_removes_managed_path() -> None:
+    from printguard.server import platform
+
+    source = SimpleNamespace(close=Mock())
+    server = object.__new__(platform.ServerPlatform)
+    server.mediamtx = SimpleNamespace(remove_path=AsyncMock())
+    server._sources = {"camera": source}
+
+    await server.release_camera("camera", {"kind": "url", "url": "rtsp://camera/live"})
+
+    source.close.assert_called_once()
+    server.mediamtx.remove_path.assert_awaited_once_with("camera")
 
 
 async def test_camera_source_converts_only_grabbed_frames(monkeypatch) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 
 import httpx
+import numpy as np
 import pytest
 
 from fakes import FakePlatform
@@ -227,7 +228,7 @@ def test_callable_mjpeg_sources_cap_pyav_probe(monkeypatch) -> None:
 def test_direct_camera_source_wakes_for_viewers(monkeypatch) -> None:
     from printguard.server import platform
 
-    monkeypatch.setattr(platform.threading.Thread, "start", lambda self: None)
+    monkeypatch.setattr(platform.AVSource, "_run", lambda self: None)
     source = platform.AVSource("http://camera/stream", "rtsp://mediamtx/camera")
     source.set_monitoring(False)
     assert source.standby
@@ -239,7 +240,7 @@ def test_direct_camera_source_wakes_for_viewers(monkeypatch) -> None:
 def test_pullable_camera_source_leaves_viewing_to_mediamtx(monkeypatch) -> None:
     from printguard.server import platform
 
-    monkeypatch.setattr(platform.threading.Thread, "start", lambda self: None)
+    monkeypatch.setattr(platform.AVSource, "_run", lambda self: None)
     source = platform.AVSource("rtsp://mediamtx/camera")
     source.set_monitoring(False)
     source.view()
@@ -250,7 +251,7 @@ def test_pullable_camera_source_leaves_viewing_to_mediamtx(monkeypatch) -> None:
 async def test_camera_source_converts_only_grabbed_frames(monkeypatch) -> None:
     from printguard.server import platform
 
-    monkeypatch.setattr(platform.threading.Thread, "start", lambda self: None)
+    monkeypatch.setattr(platform.AVSource, "_run", lambda self: None)
 
     class VideoFrame:
         def __init__(self) -> None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from contextlib import asynccontextmanager
+from types import SimpleNamespace
+from unittest.mock import Mock
 
 import httpx
 import numpy as np
@@ -229,8 +231,12 @@ def test_direct_camera_source_wakes_for_viewers(monkeypatch) -> None:
     from printguard.server import platform
 
     monkeypatch.setattr(platform.AVSource, "_run", lambda self: None)
+    now = [100.0]
+    monkeypatch.setattr(platform.time, "monotonic", lambda: now[0])
     source = platform.AVSource("http://camera/stream", "rtsp://mediamtx/camera")
     source.set_monitoring(False)
+    assert not source.standby
+    now[0] += platform.DEMAND_IDLE_S
     assert source.standby
     source.view()
     assert not source.standby
@@ -241,11 +247,26 @@ def test_pullable_camera_source_leaves_viewing_to_mediamtx(monkeypatch) -> None:
     from printguard.server import platform
 
     monkeypatch.setattr(platform.AVSource, "_run", lambda self: None)
+    now = [100.0]
+    monkeypatch.setattr(platform.time, "monotonic", lambda: now[0])
     source = platform.AVSource("rtsp://mediamtx/camera")
     source.set_monitoring(False)
+    now[0] += platform.DEMAND_IDLE_S
     source.view()
     assert source.standby
     source.close()
+
+
+async def test_view_camera_renews_demand_after_cold_start() -> None:
+    from printguard.server import platform
+
+    source = SimpleNamespace(online=True, view=Mock(return_value=True))
+    server = object.__new__(platform.ServerPlatform)
+    server._sources = {"camera": source}
+
+    await server.view_camera("camera")
+
+    assert source.view.call_count == 2
 
 
 async def test_camera_source_converts_only_grabbed_frames(monkeypatch) -> None:

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
 import httpx
 
-from printguard.server.app import ASSET_CACHE_CONTROL, REVALIDATE_CACHE_CONTROL, WebStaticFiles
+from printguard.server.app import ASSET_CACHE_CONTROL, REVALIDATE_CACHE_CONTROL, WebStaticFiles, create_app
+
+
+class AsyncContent(httpx.AsyncByteStream):
+    async def __aiter__(self):
+        yield b"#EXTM3U"
 
 
 async def test_web_static_files_revalidate_html_and_cache_hashed_assets(tmp_path) -> None:
@@ -22,3 +30,22 @@ async def test_web_static_files_revalidate_html_and_cache_hashed_assets(tmp_path
     assert asset.headers["cache-control"] == ASSET_CACHE_CONTROL
     assert unchanged.status_code == 304 and unchanged.headers["cache-control"] == REVALIDATE_CACHE_CONTROL
     assert "etag" in html.headers and "etag" in asset.headers
+
+
+async def test_hls_view_wakes_camera_before_proxying() -> None:
+    platform = SimpleNamespace(view_camera=AsyncMock())
+    app = create_app()
+    app.state.engine = SimpleNamespace(platform=platform)
+    app.state.hls = httpx.AsyncClient(
+        base_url="http://mediamtx",
+        transport=httpx.MockTransport(lambda request: httpx.Response(200, stream=AsyncContent(), request=request)),
+    )
+
+    try:
+        async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test") as client:
+            response = await client.get("/hls/camera-one/index.m3u8")
+    finally:
+        await app.state.hls.aclose()
+
+    assert response.content == b"#EXTM3U"
+    platform.view_camera.assert_awaited_once_with("camera-one")

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -108,6 +108,18 @@ async def test_defect_pipeline() -> None:
     assert ("POST", "http://disc/hook") in platform.http_calls, "Discord alert was never delivered"
 
 
+async def test_alert_only_notification_wording() -> None:
+    platform = FakePlatform(infer_s=0.02, failing=True)
+    async with running_engine(platform, camera_fps=[10.0]) as (engine, _events):
+        monitor_id = next(iter(engine.monitors))
+        await engine.handle({"cmd": "settings.update", "patch": {"notifiers": {"ntfy": {"url": "http://ntfy/topic"}}}})
+        await engine.handle({"cmd": "monitor.update", "id": monitor_id, "patch": {"notify": True, "consecutive": 1}})
+        await asyncio.sleep(1.0)
+
+    request = next(request for request in platform.http_requests if request["url"] == "http://ntfy/topic")
+    assert request["headers"]["Message"] == "Alert only: no printer action configured"
+
+
 async def test_standby_gating() -> None:
     watchdog.DEVICE_POLL_S = 0.1
     platform = FakePlatform(infer_s=0.02, failing=True)

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -124,11 +124,11 @@ async def test_slow_printer_action_does_not_pause_inference(monkeypatch) -> None
     monkeypatch.setattr(watchdog, "ACT_ATTEMPTS", 1)
     monkeypatch.setattr(watchdog, "ACT_RETRY_S", 0.01)
     monkeypatch.setattr(watchdog, "WATCH_TICK_S", 0.02)
-    monkeypatch.setattr(watchdog, "STALL_GRACE_S", 0.1)
+    monkeypatch.setattr(watchdog, "STALL_GRACE_S", 0.2)
     platform = FakePlatform(infer_s=0.02)
     platform.action_delay_s = 0.4
     platform.reject_actions = True
-    async with running_engine(platform, camera_fps=[10.0]) as (engine, events):
+    async with running_engine(platform, camera_fps=[30.0]) as (engine, events):
         monitor_id = next(iter(engine.monitors))
         printer_id = await _register_printer(engine)
         await engine.handle(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -131,6 +131,65 @@ async def test_standby_gating() -> None:
     assert resumed > 0, "inference did not resume when printing started"
 
 
+async def test_restored_camera_attachment_is_single_flight(monkeypatch) -> None:
+    from fakes import FakeSource
+    from printguard.engine import engine as engine_module
+    from printguard.engine.registry import Camera
+
+    platform = FakePlatform()
+    platform.state = {
+        "cameras": [Camera(id="slow", name="Slow", source={"kind": "fake", "fps": 30.0}, max_fps=30.0).persisted()]
+    }
+    release = asyncio.Event()
+    attempts = 0
+
+    async def open_camera(camera_id, source):
+        nonlocal attempts
+        attempts += 1
+        await release.wait()
+        return FakeSource(30.0)
+
+    monkeypatch.setattr(platform, "open_camera", open_camera)
+    monkeypatch.setattr(engine_module, "STATE_TICK_S", 0.01)
+    monkeypatch.setattr(engine_module, "REATTACH_EVERY_TICKS", 1)
+    engine = Engine(platform)
+    await engine.start()
+    try:
+        await asyncio.sleep(0.05)
+        assert attempts == 1
+        release.set()
+        await asyncio.sleep(0.02)
+        assert engine.cameras.get("slow").frame_source is not None
+    finally:
+        await engine.stop()
+
+
+async def test_removing_camera_cancels_pending_attachment(monkeypatch) -> None:
+    from printguard.engine.registry import Camera
+
+    platform = FakePlatform()
+    platform.state = {
+        "cameras": [Camera(id="slow", name="Slow", source={"kind": "fake", "fps": 30.0}, max_fps=30.0).persisted()]
+    }
+    started = asyncio.Event()
+
+    async def open_camera(camera_id, source):
+        started.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(platform, "open_camera", open_camera)
+    engine = Engine(platform)
+    await engine.start()
+    await started.wait()
+
+    await engine._drop_camera("slow")
+
+    assert engine.cameras.get("slow") is None
+    assert "slow" not in engine._attach_tasks
+    assert platform.released_cameras == ["slow"]
+    await engine.stop()
+
+
 async def test_watchdog_and_failed_action() -> None:
     watchdog.DEVICE_POLL_S = 0.1
     watchdog.WATCH_TICK_S = 0.05

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -120,6 +120,37 @@ async def test_alert_only_notification_wording() -> None:
     assert request["headers"]["Message"] == "Alert only: no printer action configured"
 
 
+async def test_slow_printer_action_does_not_pause_inference(monkeypatch) -> None:
+    monkeypatch.setattr(watchdog, "ACT_ATTEMPTS", 1)
+    monkeypatch.setattr(watchdog, "ACT_RETRY_S", 0.01)
+    monkeypatch.setattr(watchdog, "WATCH_TICK_S", 0.02)
+    monkeypatch.setattr(watchdog, "STALL_GRACE_S", 0.1)
+    platform = FakePlatform(infer_s=0.02)
+    platform.action_delay_s = 0.4
+    platform.reject_actions = True
+    async with running_engine(platform, camera_fps=[10.0]) as (engine, events):
+        monitor_id = next(iter(engine.monitors))
+        printer_id = await _register_printer(engine)
+        await engine.handle(
+            {
+                "cmd": "monitor.update",
+                "id": monitor_id,
+                "patch": {"printer_id": printer_id, "on_defect": "pause", "consecutive": 1},
+            }
+        )
+        platform.failing = True
+        await asyncio.wait_for(platform.action_started.wait(), 1.0)
+        before = len([event for event in events if event.get("event") == "result"])
+        await asyncio.sleep(0.2)
+        after = len([event for event in events if event.get("event") == "result"])
+        await asyncio.sleep(0.3)
+        alerts = [event for event in events if event.get("event") == "alert"]
+
+    assert after > before, "printer action I/O paused inference"
+    assert alerts and alerts[0]["action"] == "failed", "failed printer action did not complete in the background"
+    assert not any(event.get("event") == "warning" and "feed has stalled" in event["message"] for event in events)
+
+
 async def test_standby_gating() -> None:
     watchdog.DEVICE_POLL_S = 0.1
     platform = FakePlatform(infer_s=0.02, failing=True)
@@ -237,6 +268,35 @@ async def test_watchdog_and_failed_action(monkeypatch) -> None:
         assert camera.frame_source is not failed_source and camera.online, "failed camera source was not attached afresh"
     recoveries = [e for e in events if e.get("event") == "warning" and e["recovered"]]
     assert any("back" in r["message"] for r in recoveries), "camera recovery was not announced"
+
+
+async def test_watchdog_restarts_stalled_camera_after_fresh_inference(monkeypatch) -> None:
+    from printguard.engine import engine as engine_module
+
+    monkeypatch.setattr(watchdog, "WATCH_TICK_S", 0.02)
+    monkeypatch.setattr(watchdog, "STALL_GRACE_S", 0.1)
+    monkeypatch.setattr(engine_module, "STATE_TICK_S", 0.02)
+    platform = FakePlatform(infer_s=0.01)
+    async with running_engine(platform, camera_fps=[20.0]) as (engine, events):
+        camera = next(iter(engine.cameras.values()))
+        await asyncio.sleep(0.1)
+        stalled_source = camera.frame_source
+        stalled_source.frozen = True
+        await asyncio.sleep(0.5)
+
+        assert camera.frame_source is not stalled_source and camera.online, "stalled camera source was not attached afresh"
+        assert camera.id in platform.released_cameras, "stalled camera resources were not released"
+        stalled_index = next(
+            index
+            for index, event in enumerate(events)
+            if event.get("event") == "warning" and "feed has stalled" in event["message"]
+        )
+        recovered_index = next(
+            index
+            for index, event in enumerate(events)
+            if event.get("event") == "warning" and event["recovered"] and "feed recovered" in event["message"]
+        )
+        assert any(event.get("event") == "result" for event in events[stalled_index + 1 : recovered_index])
 
 
 async def test_protocol_surfaces_errors_and_filters_settings() -> None:

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -119,11 +119,14 @@ async def test_standby_gating() -> None:
         await asyncio.sleep(1.0)
         assert not engine.state_event()["monitors"][0]["watching"], "idle printer should be in standby"
         assert not engine.cameras.schedulable(), "standby monitor's camera should not be scheduled"
+        camera = engine.cameras.values()[0]
+        assert camera.standby and not camera.online, "standby camera capture should sleep"
         results_during_standby = len([e for e in events if e.get("event") == "result"])
 
         platform.device_status = "Printing"
         await asyncio.sleep(1.0)
         assert engine.state_event()["monitors"][0]["watching"], "printing printer should be watched"
+        assert not camera.standby and camera.online, "printing should wake camera capture"
         resumed = len([e for e in events if e.get("event") == "result"]) - results_during_standby
     assert resumed > 0, "inference did not resume when printing started"
 

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -190,11 +190,15 @@ async def test_removing_camera_cancels_pending_attachment(monkeypatch) -> None:
     await engine.stop()
 
 
-async def test_watchdog_and_failed_action() -> None:
+async def test_watchdog_and_failed_action(monkeypatch) -> None:
+    from printguard.engine import engine as engine_module
+
     watchdog.DEVICE_POLL_S = 0.1
     watchdog.WATCH_TICK_S = 0.05
     watchdog.OFFLINE_GRACE_S = 0.2
     watchdog.ACT_RETRY_S = 0.01
+    monkeypatch.setattr(engine_module, "STATE_TICK_S", 0.05)
+    monkeypatch.setattr(engine_module, "REATTACH_EVERY_TICKS", 1)
     platform = FakePlatform(infer_s=0.02, failing=True)
     platform.reject_actions = True
     async with running_engine(platform, camera_fps=[10.0]) as (engine, events):
@@ -211,14 +215,14 @@ async def test_watchdog_and_failed_action() -> None:
         assert any("pause failed" in e["message"] for e in errors), "failed action did not emit an error event"
 
         camera = next(iter(engine.cameras.values()))
-        camera.frame_source.online = False
+        failed_source = camera.frame_source
+        failed_source.online = False
         await asyncio.sleep(0.6)
         warnings = [e for e in events if e.get("event") == "warning" and not e["recovered"]]
         assert any("offline" in w["message"] for w in warnings), "camera outage did not warn"
         assert any(url == "http://ntfy/topic" for _, url in platform.http_calls), "outage warning was not pushed to notifiers"
-
-        camera.frame_source.online = True
-        await asyncio.sleep(0.3)
+        assert camera.id in platform.released_cameras, "failed camera resources were not released"
+        assert camera.frame_source is not failed_source and camera.online, "failed camera source was not attached afresh"
     recoveries = [e for e in events if e.get("event") == "warning" and e["recovered"]]
     assert any("back" in r["message"] for r in recoveries), "camera recovery was not announced"
 

--- a/tests/test_mediamtx.py
+++ b/tests/test_mediamtx.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+import json
+
+import httpx
 import pytest
 
-from printguard.server.mediamtx import pull_source
+from printguard.server.mediamtx import MediaMTX, pull_source
 
 
 @pytest.mark.parametrize(
@@ -30,3 +33,21 @@ def test_pull_source_routes_urls(url: str, pulled: str | None) -> None:
 def test_pull_source_rejects_non_whep_webrtc(url: str) -> None:
     with pytest.raises(ValueError, match="does not expose WHEP"):
         pull_source(url)
+
+
+async def test_managed_pull_sources_start_on_demand() -> None:
+    requests: list[httpx.Request] = []
+
+    def handle(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(200)
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handle)) as client:
+        await MediaMTX("http://mediamtx", "rtsp://mediamtx", client).ensure_path("camera", "rtsp://camera/live")
+
+    assert json.loads(requests[0].content) == {
+        "source": "rtsp://camera/live",
+        "sourceOnDemand": True,
+        "sourceOnDemandStartTimeout": "30s",
+        "sourceOnDemandCloseAfter": "10s",
+    }

--- a/tests/test_mqtt.py
+++ b/tests/test_mqtt.py
@@ -1,5 +1,5 @@
 """MQTT bridge protocol shapes: Home Assistant discovery payloads, the
-per-monitor state blob and inbound command routing — the pure functions the
+per-monitor state blob and inbound command routing - the pure functions the
 bridge's aiomqtt session is a thin wrapper around."""
 
 from __future__ import annotations

--- a/uv.lock
+++ b/uv.lock
@@ -1090,7 +1090,7 @@ wheels = [
 
 [[package]]
 name = "printguard"
-version = "2.3.5"
+version = "2.3.6"
 source = { editable = "." }
 dependencies = [
     { name = "ai-edge-litert" },

--- a/web/src/components/CameraRail.tsx
+++ b/web/src/components/CameraRail.tsx
@@ -38,7 +38,7 @@ function CameraCard({ camera }: { camera: Camera }) {
         <span
           aria-hidden
           className={`led ${camera.inferring ? "led-infer" : camera.online ? "led-on" : "led-off"}`}
-          title={camera.online ? "online" : "offline"}
+          title={camera.online ? "online" : camera.standby ? "standby" : "offline"}
         />
       )}
       <div className="order-1 min-w-0 flex-1 leading-tight sm:flex-none sm:w-36">

--- a/web/src/components/CameraRail.tsx
+++ b/web/src/components/CameraRail.tsx
@@ -37,7 +37,7 @@ function CameraCard({ camera }: { camera: Camera }) {
       ) : (
         <span
           aria-hidden
-          className={`led ${camera.inferring ? "led-infer" : camera.online ? "led-on" : "led-off"}`}
+          className={`led ${camera.online ? "led-on" : "led-off"}`}
           title={camera.online ? "online" : camera.standby ? "standby" : "offline"}
         />
       )}

--- a/web/src/components/CamerasDialog.tsx
+++ b/web/src/components/CamerasDialog.tsx
@@ -54,7 +54,7 @@ function CameraRow({ camera, focus }: { camera: Camera; focus: boolean }) {
   return (
     <div ref={ref} className="panel overflow-hidden">
       <div className="flex items-center gap-3 px-3 py-2">
-        <span className={`led ${camera.online ? "led-on" : "led-off"}`} />
+        <span className={`led ${camera.online ? "led-on" : "led-off"}`} title={camera.online ? "online" : camera.standby ? "standby" : "offline"} />
         <div className="flex-1 min-w-0 leading-tight">
           <div className="text-sm font-medium truncate">{camera.name}</div>
           <div className="mono text-[0.62rem] text-text-2 truncate">{sourceLabel(camera.source)}</div>

--- a/web/src/components/CamerasDialog.tsx
+++ b/web/src/components/CamerasDialog.tsx
@@ -136,13 +136,14 @@ function CameraRow({ camera, focus }: { camera: Camera; focus: boolean }) {
   );
 }
 
-function CameraList({ cameras }: { cameras: Camera[] }) {
+function CameraList({ cameras, focusId }: { cameras: Camera[]; focusId?: string | null }) {
   const { focusCameraId } = useStore();
+  const focused = focusId ?? focusCameraId;
   if (!cameras.length) return null;
   return (
     <div className="space-y-2 mb-6">
       {cameras.map((camera) => (
-        <CameraRow key={camera.id} camera={camera} focus={camera.id === focusCameraId} />
+        <CameraRow key={camera.id} camera={camera} focus={camera.id === focused} />
       ))}
     </div>
   );
@@ -214,7 +215,7 @@ function DevicePicker({ onAdd }: { onAdd: (name: string, source: CameraSource) =
   );
 }
 
-function HubAdd({ onDone }: { onDone: () => void }) {
+function HubAdd({ onDone, onDeviceAdd }: { onDone: () => void; onDeviceAdd: (name: string, source: CameraSource) => void }) {
   const { send, toast, isPending } = useStore();
   const desktopApp = "pywebview" in window;
   const [tab, setTab] = useState<"url" | "publish">("url");
@@ -296,12 +297,7 @@ function HubAdd({ onDone }: { onDone: () => void }) {
             This computer's cameras register on the hub itself, so they keep watching from the tray
             with every window closed.
           </p>
-          <DevicePicker
-            onAdd={(name, source) => {
-              send({ cmd: "camera.add", name, source });
-              onDone();
-            }}
-          />
+          <DevicePicker onAdd={onDeviceAdd} />
         </div>
       )}
       {tab === "publish" && !desktopApp && (
@@ -333,6 +329,12 @@ export function CamerasDialog() {
   const close = () => openDialog(null);
   const isLocal = engine?.mode === "local";
   const cameras = engine?.cameras ?? [];
+  const [previewDeviceId, setPreviewDeviceId] = useState<string | null>(null);
+  const previewCameraId = cameras.find((camera) => camera.source.device_id === previewDeviceId)?.id;
+  const registerDevice = (name: string, source: CameraSource) => {
+    setPreviewDeviceId(source.device_id ?? null);
+    send({ cmd: "camera.add", name, source });
+  };
   const focusIsPrinter = cameras.some((c) => c.id === focusCameraId && c.printer_id);
   const [tab, setTab] = useState<"cameras" | "printers">(focusIsPrinter ? "printers" : "cameras");
   const tabs: Array<["cameras" | "printers", string]> = [
@@ -354,12 +356,12 @@ export function CamerasDialog() {
       </div>
       {tab === "cameras" ? (
         <>
-          <CameraList cameras={cameras.filter((c) => !c.printer_id)} />
+          <CameraList cameras={cameras.filter((c) => !c.printer_id)} focusId={previewCameraId} />
           <div className="label mb-3">Register new</div>
           {isLocal ? (
-            <DevicePicker onAdd={(name, source) => send({ cmd: "camera.add", name, source })} />
+            <DevicePicker onAdd={registerDevice} />
           ) : (
-            <HubAdd onDone={() => {}} />
+            <HubAdd onDone={() => {}} onDeviceAdd={registerDevice} />
           )}
         </>
       ) : (

--- a/web/src/components/DetailPanel.tsx
+++ b/web/src/components/DetailPanel.tsx
@@ -83,7 +83,7 @@ export function DetailPanel({ monitor }: { monitor: Monitor }) {
         <div className="sticky top-0 z-10 bg-ink-1/95 backdrop-blur-sm flex items-center gap-2.5 px-5 py-3.5 border-b border-line-0">
           <span
             aria-hidden
-            className={`led ${monitor.alert ? "led-bad" : camera?.inferring ? "led-infer" : monitor.watching && camera?.online ? "led-on" : "led-off"}`}
+            className={`led ${monitor.alert ? "led-bad" : monitor.watching && camera?.online ? "led-on" : "led-off"}`}
           />
           <h2 id={titleId} className="display text-lg font-semibold flex-1 truncate">
             {monitor.name}

--- a/web/src/components/Feed.tsx
+++ b/web/src/components/Feed.tsx
@@ -1,11 +1,11 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { renderVideoFrame, useVideoStream } from "../image";
 import type { Camera } from "../types";
 
 export function Feed({ camera, mode }: { camera: Camera | undefined; mode: string }) {
   const videoRef = useRef<HTMLVideoElement>(null);
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const online = camera?.online ?? false;
+  const [playing, setPlaying] = useState(false);
   const brightness = camera?.brightness ?? 1;
   const contrast = camera?.contrast ?? 1;
   const sharpness = camera?.sharpness ?? 0;
@@ -14,6 +14,8 @@ export function Feed({ camera, mode }: { camera: Camera | undefined; mode: strin
   const useCanvas = sharpness > 0 || crop !== null || brightness !== 1 || contrast !== 1 || rotation !== 0;
 
   useVideoStream(videoRef, camera, mode);
+
+  useEffect(() => setPlaying(false), [camera?.id]);
 
   useEffect(() => {
     if (!useCanvas) return;
@@ -41,10 +43,15 @@ export function Feed({ camera, mode }: { camera: Camera | undefined; mode: strin
         autoPlay
         muted
         playsInline
+        onPlaying={() => setPlaying(true)}
+        onWaiting={() => setPlaying(false)}
+        onPause={() => setPlaying(false)}
+        onEmptied={() => setPlaying(false)}
+        onError={() => setPlaying(false)}
         className={useCanvas ? "absolute inset-0 w-full h-full object-contain invisible" : "absolute inset-0 w-full h-full object-contain"}
       />
       {useCanvas && <canvas ref={canvasRef} className="absolute inset-0 m-auto" />}
-      {(!camera || !online) && (
+      {(!camera || !playing) && (
         <div className="absolute inset-0 grid place-items-center bg-ink-0/85 z-[2]">
           <span className="mono text-[0.65rem] tracking-[0.2em] text-text-2 uppercase">
             {camera ? (camera.standby ? "starting stream" : "no signal") : "no camera bound"}

--- a/web/src/components/Feed.tsx
+++ b/web/src/components/Feed.tsx
@@ -47,7 +47,7 @@ export function Feed({ camera, mode }: { camera: Camera | undefined; mode: strin
       {(!camera || !online) && (
         <div className="absolute inset-0 grid place-items-center bg-ink-0/85 z-[2]">
           <span className="mono text-[0.65rem] tracking-[0.2em] text-text-2 uppercase">
-            {camera ? "no signal" : "no camera bound"}
+            {camera ? (camera.standby ? "starting stream" : "no signal") : "no camera bound"}
           </span>
         </div>
       )}

--- a/web/src/components/MonitorTile.tsx
+++ b/web/src/components/MonitorTile.tsx
@@ -45,7 +45,7 @@ export function MonitorTile({ monitor, index }: { monitor: Monitor; index: numbe
         ) : (
           <span
             aria-hidden
-            className={`led ${alerting ? "led-bad" : camera?.inferring ? "led-infer" : monitor.watching && camera?.online ? "led-on" : "led-off"}`}
+            className={`led ${alerting ? "led-bad" : monitor.watching && camera?.online ? "led-on" : "led-off"}`}
           />
         )}
         <h3 className="display text-base font-semibold tracking-[0.08em] truncate flex-1">{monitor.name}</h3>

--- a/web/src/guide.tsx
+++ b/web/src/guide.tsx
@@ -76,7 +76,8 @@ export const GUIDE: GuideSection[] = [
     body: (
       <>
         A monitor binds one camera (and optionally one printer) and carries the detection thresholds
-        and defect response. Inference is shared fairly across every monitor on watch.
+        and defect response. Inference is shared fairly across every monitor on watch. Its status dot
+        is green while watching, grey in standby or offline, and red during a defect alert.
       </>
     ),
     action: { label: "Add a monitor", dialog: "monitor" },

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -38,6 +38,7 @@ export interface Camera {
   inferring: boolean;
   in_use: boolean;
   online: boolean;
+  standby: boolean;
   last_result: InferenceResult | null;
 }
 


### PR DESCRIPTION
## What changed

- Pause camera capture unless inference or HLS viewing needs frames.
- Use MediaMTX on-demand paths and convert RGB frames only when sampled.
- Preview desktop cameras immediately after registration without leaving orphaned captures.
- Keep camera and monitor status indicators stable between inference jobs.
- Recover damaged RTSP pulls and genuinely stalled camera sources automatically.
- Clarify alert-only notifications when no printer action is configured.
- Keep inference running while printer actions and notifications are slow or unreachable.
- Automate initial issue triage and post-release reporter verification.
- Replace em dashes across documentation and Python docstrings, while preserving changelog history.

## Verification

- `uv run pytest`: 180 passed
- `npm run typecheck`
- `npm run build`
- Docker and macOS desktop app checks
- Live synthetic RTSP outage and recovery through managed MediaMTX
- Synthetic frozen-camera recovery after a fresh inference result
- Synthetic unreachable printer action while inference continues
- Healthy, alert and standby indicator checks at desktop and mobile widths
- GitHub workflow YAML and embedded shell syntax checks
- Documentation and docstring punctuation scan

Sentry feedback addressed: PYTHON-5, PYTHON-6 and PYTHON-7.

Relates to #86 and #88