### PR TITLE
v2.3.9: the macOS desktop app starts again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,25 @@ release notes.
 The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.9] - 2026-08-03
+
+### Fixed
+
+- **The macOS desktop app no longer opens to a blank white window.** On 2.3.7 and 2.3.8 the
+  app started, showed an empty window and never loaded, while the menu bar icon stayed
+  alive: Core ML could not load the model from the app's own data folder, because the
+  runtime's cache lookup rejects any path containing a space and macOS puts that folder in
+  `~/Library/Application Support`. Nothing was watched for as long as the window sat there.
+  Core ML now compiles the model each time the app starts, which adds about a fifth of a
+  second to startup and no longer depends on where your data lives. Update and open the
+  app; you can delete the leftover `model-cache` folder in the data directory.
+
+- **When the server does fail to start, the window says so.** Instead of a blank page, it
+  now shows what went wrong, the end of the log and where the full log is kept, so a broken
+  start can be reported or fixed rather than guessed at. A failed start also no longer
+  leaves the bundled streaming server running behind it, holding port 8554 against the next
+  hub you start.
+
 ## [2.3.8] - 2026-07-24
 
 ### Added

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -22,6 +22,7 @@ Find the symptom, apply the fix. Every row links to the page that explains the r
 | `bind: address already in use` for `8000` or `8554` | Another PrintGuard already holds the port, often a desktop app or a container you forgot | Find the holder with `lsof -nP -iTCP:8554 -sTCP:LISTEN` on macOS or Linux, or `netstat -ano \| findstr 8554` on Windows, then stop it. Versions before 2.3.8 could leave the streaming server behind after a crash |
 | Dashboard loads but the header shows "Reconnecting" | The engine WebSocket cannot connect, usually a proxy that does not forward WebSockets, or a rewritten `Origin` | Check the proxy forwards upgrade headers, then see [origin checking](deployment.md#origin-checking) |
 | First launch of the desktop app is blocked | The builds are unsigned | macOS: **System Settings → Privacy & Security → Open Anyway**. Windows: **More info → Run anyway** |
+| The desktop app opens an empty white window | Its server did not start. 2.3.7 and 2.3.8 on macOS always hit this: Core ML could not load the model from a data directory whose path contains a space | Update to 2.3.9 or later, where the window reports what failed and shows the end of the log ([logs](#getting-logs-and-diagnostics)) |
 | Container restarts repeatedly | Usually an unwritable `/data` volume | Check the volume mount and its permissions, then read `docker logs printguard` |
 
 ## Cameras and video

--- a/printguard/server/app.py
+++ b/printguard/server/app.py
@@ -14,7 +14,7 @@ import os
 import re
 import secrets
 import time
-from contextlib import asynccontextmanager
+from contextlib import AsyncExitStack, asynccontextmanager
 from pathlib import Path
 from urllib.parse import urlsplit
 
@@ -95,30 +95,36 @@ def create_app() -> FastAPI:
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
+        """Brings the hub up, and unwinds whatever it got up however it ends.
+
+        Startup can fail part way - a port already held, a model runtime that will
+        not load - and the pieces already running have to come back down with it,
+        or the streaming server outlives the hub and keeps its ports from the next
+        one. A stack releases them in reverse, on that path as on a clean stop.
+        """
         logger.info("hub starting (data=%s, models=%s, static=%s)", data_dir, model_dir, static_dir)
-        streamer = None
-        if mediamtx_binary and Path(mediamtx_binary).exists():
-            streamer = EmbeddedMediaMTX(mediamtx_binary, mediamtx_config, mediamtx_api)
-            await streamer.start()
-        else:
-            logger.warning("no bundled MediaMTX binary (%r) — expecting an external MediaMTX at %s", mediamtx_binary, mediamtx_api)
-        platform = ServerPlatform(model_dir, data_dir, mediamtx_api, mediamtx_rtsp, update_asset)
-        engine = Engine(platform)
-        await engine.start()
-        app.state.engine = engine
-        api_app.state.engine = engine
-        app.state.hls = httpx.AsyncClient(base_url=mediamtx_hls, timeout=httpx.Timeout(10.0, read=60.0))
-        bridge = MqttBridge(engine, lambda: engine.settings.get("mqtt", {}))
-        bridge.start()
-        async with mcp_app.lifespan(app):
+        async with AsyncExitStack() as resources:
+            if mediamtx_binary and Path(mediamtx_binary).exists():
+                streamer = EmbeddedMediaMTX(mediamtx_binary, mediamtx_config, mediamtx_api)
+                await streamer.start()
+                resources.push_async_callback(streamer.stop)
+            else:
+                logger.warning("no bundled MediaMTX binary (%r) — expecting an external MediaMTX at %s", mediamtx_binary, mediamtx_api)
+            platform = ServerPlatform(model_dir, data_dir, mediamtx_api, mediamtx_rtsp, update_asset)
+            resources.push_async_callback(platform.close)
+            engine = Engine(platform)
+            await engine.start()
+            resources.push_async_callback(engine.stop)
+            app.state.engine = engine
+            api_app.state.engine = engine
+            app.state.hls = httpx.AsyncClient(base_url=mediamtx_hls, timeout=httpx.Timeout(10.0, read=60.0))
+            resources.push_async_callback(app.state.hls.aclose)
+            bridge = MqttBridge(engine, lambda: engine.settings.get("mqtt", {}))
+            bridge.start()
+            resources.push_async_callback(bridge.stop)
+            await resources.enter_async_context(mcp_app.lifespan(app))
             yield
-        logger.info("hub shutting down")
-        await bridge.stop()
-        await app.state.hls.aclose()
-        await engine.stop()
-        await platform.close()
-        if streamer is not None:
-            await streamer.stop()
+            logger.info("hub shutting down")
 
     app = FastAPI(title="PrintGuard", lifespan=lifespan)
     pysrc = build_pysrc()

--- a/printguard/server/desktop.py
+++ b/printguard/server/desktop.py
@@ -11,6 +11,7 @@ lifecycle differ from the container entry point in :mod:`printguard.server.app`.
 
 from __future__ import annotations
 
+import html
 import io
 import logging
 import multiprocessing
@@ -22,6 +23,8 @@ import threading
 import time
 from importlib import metadata
 from pathlib import Path
+from string import Template
+from typing import Any
 
 import platformdirs
 import pystray
@@ -38,7 +41,29 @@ BUNDLE_ID = "io.printguard.desktop"
 REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 READY_TIMEOUT_S = 30.0
 STOP_TIMEOUT_S = 10.0
+FAILURE_LOG_LINES = 30
 WIN_RUN_KEY = r"Software\Microsoft\Windows\CurrentVersion\Run"
+
+FAILURE_PAGE = Template("""<!doctype html>
+<meta charset="utf-8">
+<title>PrintGuard</title>
+<style>
+  :root { color-scheme: light dark; }
+  body { font: 14px/1.6 -apple-system, "Segoe UI", system-ui, sans-serif; margin: 0; padding: 40px 44px; }
+  h1 { font-size: 19px; margin: 0 0 14px; }
+  p { margin: 0 0 14px; max-width: 62ch; }
+  code { font-size: 13px; }
+  pre { background: rgba(127, 127, 127, 0.14); border-radius: 10px; font-size: 12px; overflow: auto; padding: 16px; }
+</style>
+<h1>PrintGuard could not start</h1>
+<p>Its server stopped while starting up, so there is nothing to show here and no printer is
+being watched. The reason is at the end of the log below, kept in full at
+<code>$log</code>.</p>
+<p>Quit PrintGuard from its menu bar or system tray icon and open it again once the cause is
+dealt with. If the log does not explain it, report it with the log attached at
+<a href="https://github.com/oliverbravery/PrintGuard/issues">github.com/oliverbravery/PrintGuard/issues</a>.</p>
+<pre>$log_tail</pre>
+""")
 
 PLIST_TEMPLATE = """<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -123,8 +148,8 @@ def _enable_wkwebview_camera() -> None:
             decision_handler(1)
 
 
-def _run_webview(url: str) -> None:
-    """Child-process entry point: shows the hub in a native window.
+def _run_webview(**contents: Any) -> None:
+    """Child-process entry point: shows the hub, or why it is not there, in a native window.
 
     The window owns its process's main thread, so it never contends with the
     tray's, and closing it ends only this process. The webview must keep its
@@ -136,7 +161,7 @@ def _run_webview(url: str) -> None:
     if sys.platform == "darwin":
         _enable_wkwebview_camera()
     webview.settings["OPEN_EXTERNAL_LINKS_IN_BROWSER"] = True
-    webview.create_window(APP_NAME, url, width=1280, height=820)
+    webview.create_window(APP_NAME, width=1280, height=820, **contents)
     webview.start(private_mode=False, storage_path=os.path.join(os.environ["DATA_DIR"], "webview"))
 
 
@@ -144,18 +169,25 @@ def _webview_url(port: int) -> str:
     return f"http://localhost:{port}/?v={metadata.version('printguard')}"
 
 
+def _failure_page() -> str:
+    """The page shown in place of the hub when its server never came up."""
+    return FAILURE_PAGE.substitute(
+        log=html.escape(os.environ["LOG_FILE"]), log_tail=html.escape("\n".join(logs.recent()[-FAILURE_LOG_LINES:]))
+    )
+
+
 class _Window:
     """Shows the hub window in a child process spawned from the tray."""
 
-    def __init__(self, url: str) -> None:
-        self._url = url
+    def __init__(self, **contents: Any) -> None:
+        self._contents = contents
         self._context = multiprocessing.get_context("spawn")
         self._process: multiprocessing.process.BaseProcess | None = None
 
     def open(self) -> None:
         """Opens the window, reusing the existing one if it is still up."""
         if self._process is None or not self._process.is_alive():
-            self._process = self._context.Process(target=_run_webview, args=(self._url,), daemon=True)
+            self._process = self._context.Process(target=_run_webview, kwargs=self._contents, daemon=True)
             self._process.start()
 
     def close(self) -> None:
@@ -176,13 +208,19 @@ class _Server:
         self._server.install_signal_handlers = lambda: None
         self._thread = threading.Thread(target=self._server.run, daemon=True)
 
-    def start(self) -> None:
-        """Starts serving and blocks until startup (engine and streamer) completes."""
+    def start(self) -> bool:
+        """Starts serving, blocks until startup completes, and reports whether it did.
+
+        A startup that fails ends the serving thread, so the wait stops there
+        instead of running the timeout out: what the window shows next depends on
+        the answer, and the user should not sit in front of a blank one until then.
+        """
         self._thread.start()
         deadline = time.monotonic() + READY_TIMEOUT_S
-        while time.monotonic() < deadline and not self._server.started:
+        while time.monotonic() < deadline and self._thread.is_alive() and not self._server.started:
             time.sleep(0.1)
         logger.info("hub server %s on :%d", "listening" if self._server.started else "did not start", self._port)
+        return self._server.started
 
     def stop(self) -> None:
         """Asks the server to exit and waits for the thread to finish."""
@@ -326,8 +364,7 @@ def main() -> None:
     logger.info("desktop app starting (frozen=%s, data=%s)", getattr(sys, "frozen", False), os.environ["DATA_DIR"])
     port = int(os.environ.get("PORT", "8000"))
     server = _Server(port)
-    server.start()
-    window = _Window(_webview_url(port))
+    window = _Window(url=_webview_url(port)) if server.start() else _Window(html=_failure_page())
     window.open()
     if sys.platform == "darwin":
         _watch_termination(window, server)

--- a/printguard/server/inference.py
+++ b/printguard/server/inference.py
@@ -83,11 +83,19 @@ def _measure_concurrency(model: Model) -> tuple[int, float]:
 
 
 class OnnxInference:
-    """Runs the ONNX model through the fastest available execution provider."""
+    """Runs the ONNX model through the fastest available execution provider.
+
+    Core ML compiles the model on every session rather than into a cache directory.
+    Its cache lookup builds the model URL with `NSURL URLWithString`, which yields
+    nil for any path holding a space, so a cache under `~/Library/Application
+    Support` fails every session it is meant to speed up - and the desktop app,
+    which is where that path is used, could not start at all. Compiling costs
+    about 0.2s per session.
+    """
 
     runtime = "onnx"
 
-    def __init__(self, model_path: Path, cache_dir: Path) -> None:
+    def __init__(self, model_path: Path) -> None:
         self._resources = ExitStack()
         registered = self._register_plugins()
         if sys.platform == "win32":
@@ -99,16 +107,10 @@ class OnnxInference:
             options.set_provider_selection_policy(ort.OrtExecutionProviderDevicePolicy.MAX_PERFORMANCE)
             self._session = ort.InferenceSession(str(model_path), sess_options=options)
         elif "CoreMLExecutionProvider" in ort.get_available_providers():
-            cache_dir.mkdir(parents=True, exist_ok=True)
             providers = [
                 (
                     "CoreMLExecutionProvider",
-                    {
-                        "ModelFormat": "MLProgram",
-                        "MLComputeUnits": "ALL",
-                        "RequireStaticInputShapes": "1",
-                        "ModelCacheDirectory": str(cache_dir),
-                    },
+                    {"ModelFormat": "MLProgram", "MLComputeUnits": "ALL", "RequireStaticInputShapes": "1"},
                 ),
                 "CPUExecutionProvider",
             ]
@@ -201,10 +203,10 @@ class LiteRtInference:
 class Inference:
     """Runs the requested model runtime at the concurrency it measurably sustains."""
 
-    def __init__(self, model_dir: Path, cache_dir: Path, runtime: InferenceRuntime) -> None:
+    def __init__(self, model_dir: Path, runtime: InferenceRuntime) -> None:
         candidates: list[OnnxInference | LiteRtInference] = []
         if runtime in ("auto", "onnx"):
-            candidates.append(OnnxInference(model_dir / "encoder_float32.onnx", cache_dir))
+            candidates.append(OnnxInference(model_dir / "encoder_float32.onnx"))
         if runtime in ("auto", "litert"):
             candidates.append(LiteRtInference(model_dir / "encoder_float32.tflite"))
         measured = [_measure_concurrency(candidate.run) for candidate in candidates]

--- a/printguard/server/platform.py
+++ b/printguard/server/platform.py
@@ -399,7 +399,7 @@ class ServerPlatform:
         self.update_asset = update_asset
         data_dir.mkdir(parents=True, exist_ok=True)
         self._model_dir = model_dir
-        self._model_cache = data_dir / "model-cache"
+        self._inference: Inference | None = None
         self.workers = 1
         self.inference_device = "Initialising"
         meta = json.loads((model_dir / "metadata.json").read_text())
@@ -413,8 +413,8 @@ class ServerPlatform:
     async def configure(self, settings: dict[str, Any]) -> None:
         """Selects the requested inference runtime."""
         runtime = settings["inference_runtime"]
-        inference = await asyncio.to_thread(Inference, self._model_dir, self._model_cache, runtime)
-        previous = getattr(self, "_inference", None)
+        inference = await asyncio.to_thread(Inference, self._model_dir, runtime)
+        previous = self._inference
         self._inference = inference
         self.workers = inference.workers
         self.inference_device = inference.device
@@ -429,9 +429,10 @@ class ServerPlatform:
         )
 
     async def close(self) -> None:
-        """Releases the HTTP client and inference workers."""
+        """Releases the HTTP client, and the inference workers once a runtime is up."""
         await self._client.aclose()
-        self._inference.close()
+        if self._inference is not None:
+            self._inference.close()
 
     async def infer(self, rgb: np.ndarray) -> dict[str, Any]:
         """Runs the model through the selected hardware provider."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "printguard"
-version = "2.3.8"
+version = "2.3.9"
 description = "Real-time 3D print failure detection"
 
 license = "GPL-2.0-only"

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import httpx
+import pytest
 
 from printguard.server.app import ASSET_CACHE_CONTROL, REVALIDATE_CACHE_CONTROL, WebStaticFiles, create_app
 from printguard.server.events import ConflatedEventQueue
@@ -79,3 +80,29 @@ async def test_hls_view_wakes_camera_before_proxying() -> None:
 
     assert response.content == b"#EXTM3U"
     platform.view_camera.assert_awaited_once_with("camera-one")
+
+
+async def test_failed_startup_stops_the_streaming_server(monkeypatch, tmp_path) -> None:
+    """A hub that cannot finish starting takes the streaming server down with it.
+
+    Left running, it holds the streaming ports for as long as the process lives and
+    blocks the next hub started on that host, so an engine that will not start must
+    not strand it.
+    """
+    binary = tmp_path / "mediamtx"
+    binary.touch()
+    streamer = SimpleNamespace(start=AsyncMock(), stop=AsyncMock())
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("MEDIAMTX_BINARY", str(binary))
+    monkeypatch.setattr("printguard.server.app.EmbeddedMediaMTX", lambda *_: streamer)
+    monkeypatch.setattr(
+        "printguard.server.app.Engine",
+        lambda _: SimpleNamespace(start=AsyncMock(side_effect=RuntimeError("no model runtime"))),
+    )
+    app = create_app()
+
+    with pytest.raises(RuntimeError):
+        async with app.router.lifespan_context(app):
+            pass
+
+    streamer.stop.assert_awaited_once()

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -29,12 +29,12 @@ async def test_model_inference(tmp_path: Path, runtime: str) -> None:
     assert platform.workers > 0
 
 
-async def test_runtimes_agree_on_embedding(tmp_path: Path) -> None:
+async def test_runtimes_agree_on_embedding() -> None:
     """Both runtimes carry the same model, so they must embed a frame the same way."""
     tensor = np.random.default_rng(0).random((1, 3, 224, 224), dtype=np.float32)
     embeddings = []
     for runtime in ("litert", "onnx"):
-        inference = Inference(Path("models"), tmp_path, runtime)
+        inference = Inference(Path("models"), runtime)
         embeddings.append(await inference.run(tensor))
         inference.close()
 

--- a/uv.lock
+++ b/uv.lock
@@ -1198,7 +1198,7 @@ wheels = [
 
 [[package]]
 name = "printguard"
-version = "2.3.8"
+version = "2.3.9"
 source = { editable = "." }
 dependencies = [
     { name = "ai-edge-litert" },


### PR DESCRIPTION
Ships v2.3.9. CHANGELOG.md has the user-facing notes; this is the reviewer's view.

## Core ML cache

2.3.7 started passing `ModelCacheDirectory` to the Core ML EP, pointed at the data
directory. ORT's cache lookup builds that URL with `[NSURL URLWithString:]` rather than
`fileURLWithPath:` ([model.mm](https://github.com/microsoft/onnxruntime/blob/main/onnxruntime/core/providers/coreml/model/model.mm),
unfixed on main at 1.27.0), and that returns nil for any path holding a space. macOS puts
the data directory in `~/Library/Application Support`, so session creation raised
`FAIL : Failed to create model URL from path`, the lifespan raised, and the desktop app
never served anything.

It looked flaky because it is SDK-gated: `URLWithString:` percent-encodes spaces only for
binaries linked against the macOS 14+ SDK, and PyInstaller stamps the exe with the SDK of
the Python it froze. A local `build.sh` app carries uv's CPython, sdk 14.2, and works. CI's
python.org build is sdk 12.1, and every published `.dmg` since 2.3.7 fails. Worth
remembering for anything frozen: reproduce with the downloaded build, not a local one.

The fix drops the cache option, so nothing hands Core ML a path. Compiling per session
costs about 0.25 s against 0.04 s warm, once at startup and once per runtime switch, and
no `model-cache` directory is written any more. Anyone stuck on a shipped 2.3.7 or 2.3.8
can set `inference_runtime` to `litert` in `state.json` to skip the ONNX candidate.

## Blank window

The window opened on a dead port and stayed white, with the reason only in the log file.
`_Server.start()` now reports whether it started, and stops waiting when the serving thread
dies instead of running the 30 s timeout out, 24 ms in practice. `_Window` takes the window
contents rather than a URL, so a failed start gets a page with the reason, the log tail and
the log path instead of nothing.

The lifespan also unwinds through an `AsyncExitStack`, in the order it did before. A
startup that failed after MediaMTX came up used to leave it holding :8554 for the life of
the tray process, which is the "address already in use" the next start hit.

## Verification

- `uv run pytest`, 194 passed, with new coverage for a failed startup stopping the
  streaming server. `npm run typecheck` clean.
- Reproduced against the published 2.3.8 app: `DATA_DIR=/tmp/pg-nospace` starts and
  benchmarks Core ML at 534 fps, `DATA_DIR="/tmp/pg space"` fails every time.
- Rebuilt the app on this branch: starts with the real spaced data directory, Core ML in
  the benchmark, no cache directory written. Failure page checked in light and dark against
  a real traceback, and the busy-port path reaches it in 24 ms.
- The published build is the one case not exercised, since a local build cannot reproduce
  the original failure. Confirm on the CI artefact before release: it should log
  `inference ready:` and leave no `model-cache` behind.
