### PR TITLE
Build the web app on the runner, not under emulation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM bluenviron/mediamtx:1.18.2 AS mediamtx
 
-FROM node:22-alpine AS web
+FROM --platform=$BUILDPLATFORM node:22-alpine AS web
 WORKDIR /build/web
 COPY web/package.json web/package-lock.json ./
 RUN npm ci


### PR DESCRIPTION
The 2.3.12 release stalled: `image (standard)` sat for 45 minutes on `[linux/arm64 web 4/7] RUN npm ci` and I cancelled it. The standard tag is the only one built for two architectures, and arm64 runs under QEMU on the Actions runners, so the UI was being compiled twice, once of them emulated. That step took 45.7 seconds in the 2.3.11 release, so something moved under us in `binfmt:latest` or `node:22-alpine`.

The web stage produces static assets that are byte-identical on every architecture, so there is no reason to build it per target. Pinning it to `$BUILDPLATFORM` builds it once, natively, and arm64 copies `dist` like it already does.

Locally, a `linux/amd64,linux/arm64` build now runs the stage once on the native platform: `npm ci` in 8.1s and `npm run build` in 3.7s, against 45.7s emulated for the install alone. The resulting image still serves the UI out of `/app/static`.

No version bump: 2.3.12 was bumped and documented in #100 but never tagged, because the `tag` job never ran, so merging this finishes that release and publishes `2.3.12` and `latest`.
