### PR TITLE
One warning per unstable camera, not one per reconnection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 
 ## [2.4.0] - 2026-08-15
 
+### Fixed
+
+- **A camera that keeps dropping out no longer notifies you every time it reconnects.** The
+  watchdog announced a recovery the moment a feed came back, so a source that reconnected in
+  a loop pushed an "offline" alert and a "back" alert on every cycle, on ntfy and every other
+  channel alike. Raising the monitor's cooldown did not help, because that setting is the
+  quiet window after a defect alert and never covered these warnings. One unstable episode is
+  now one warning: a recovery is only announced once the feed has held for a minute, and each
+  recovery doubles what the next one has to hold for, up to fifteen minutes, so a source that
+  keeps flapping gets quieter rather than louder. Outages themselves are never delayed. Worth
+  pulling if you run a camera on marginal wifi. Thanks to @subpanel0576 for the report.
+
 ## [2.3.12] - 2026-08-12
 
 ### Fixed

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -265,8 +265,8 @@ A monitor's **watching** state gates inference
 | `idle`, `paused`, `error` | No, standby | Positively not printing |
 
 Only a *positive* "not printing" stands inference down. The watchdog loop then keeps the
-pipeline honest: each sustained condition warns exactly once, after a grace period so
-reconnecting sources do not flap, and announces recovery.
+pipeline honest: each sustained condition warns exactly once, after a grace period so a
+brief outage passes unremarked, and announces recovery once health has held.
 
 ```mermaid
 stateDiagram-v2
@@ -275,10 +275,12 @@ stateDiagram-v2
     Standby --> Watching: printing, or contact lost
     Watching --> Standby: positively not printing
     Watching --> Warned: sustained fault
-    Warned --> Watching: recovered
+    Warned --> Watching: healthy for the recovery hold
     note right of Warned
         Still watching. A warning
         never stands inference down.
+        Faulting again while warned
+        stays one warning.
     end note
 ```
 
@@ -287,9 +289,12 @@ staying online but producing no fresh frames, since a frozen RTSP feed must not 
 monitoring, and a linked printer service becoming **unreachable**, since defects could no
 longer pause it.
 
-Warnings surface as dashboard toasts and go out through the notification channels. Notifier
-delivery failures and inference crashes emit `error` events. There is no silent
-`except: pass` anywhere in the alert path.
+Warnings surface as dashboard toasts and go out through the notification channels, so the
+watchdog suppresses flapping rather than repeating itself: a source that reconnects and
+drops again is still the same warning, and each announced recovery doubles how long the
+next one must hold before it is announced, up to fifteen minutes. Outages are never
+delayed, only recoveries. Notifier delivery failures and inference crashes emit `error`
+events. There is no silent `except: pass` anywhere in the alert path.
 
 ## Repository layout
 

--- a/docs/printers.md
+++ b/docs/printers.md
@@ -143,6 +143,11 @@ Alert channels live in **Settings**. Enable a channel, fill in the form and send
 alert. Every enabled channel receives defect snapshots and watchdog warnings for monitors
 that have notifications switched on.
 
+A monitor's **cooldown** is the quiet window after a defect alert. Watchdog warnings are
+separate: a camera or printer that keeps dropping out warns once for the whole unstable
+episode, and the recovery is only announced once it has stayed healthy, so reconnections
+cannot turn into a stream of notifications.
+
 | Channel | Modes | Notes |
 |---|---|---|
 | [ntfy](https://ntfy.sh) | Hub and local | Self-hostable, no account needed |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -54,6 +54,7 @@ Find the symptom, apply the fix. Every row links to the page that explains the r
 | Too many false alerts | Sensitivity or threshold too aggressive for your camera and lighting | Raise the threshold or lower sensitivity on that monitor, and raise the consecutive-frame count so brief blips are ridden out |
 | Failures caught too late | The opposite | Lower the threshold or the frame count. Watch the risk history on the monitor's detail page to pick a value |
 | No notifications arrive | The channel is off for that monitor, or the channel itself is failing | Send a test alert from **Settings**. Delivery failures raise an `error` event rather than passing silently |
+| A stream of camera offline and back notifications | The feed keeps dropping out. Before 2.4.0 every reconnection announced itself, and the monitor's cooldown only covers defect alerts | Update to 2.4.0, where one unstable episode is one warning. The drop-outs themselves are worth chasing: check the camera's own connection and, for RTSP or WHEP, that MediaMTX holds the pull |
 | Telegram is not offered | Telegram's API sends no CORS headers | Hub mode only. [Notifications](printers.md#notifications) |
 | Home Assistant shows nothing | The broker settings are wrong, or discovery is disabled in Home Assistant | Check **Settings → Home Assistant** and the broker's own log |
 

--- a/printguard/engine/watchdog.py
+++ b/printguard/engine/watchdog.py
@@ -28,6 +28,8 @@ DEVICE_POLL_S = 5.0
 NOTIFY_COOLDOWN_S = 30.0
 WATCH_TICK_S = 2.0
 OFFLINE_GRACE_S = 12.0
+RECOVER_HOLD_S = 60.0
+FLAP_HOLD_MAX_S = 900.0
 STALL_GRACE_S = 30.0
 ACT_ATTEMPTS = 3
 ACT_RETRY_S = 1.0
@@ -42,6 +44,8 @@ class Watchdog:
         self._cooldown_until: dict[str, float] = {}
         self._last_notified: dict[str, float] = {}
         self._down_since: dict[str, float] = {}
+        self._healthy_since: dict[str, float] = {}
+        self._flaps: dict[str, int] = {}
         self._warned: set[str] = set()
         self._online_since: dict[str, float] = {}
         self._tasks: set[asyncio.Task[None]] = set()
@@ -89,11 +93,12 @@ class Watchdog:
     async def watch_health(self) -> None:
         """Warns when a watched camera or printer service drops out.
 
-        Outages shorter than the grace period are ignored so reconnecting
-        sources do not flap; each sustained outage warns exactly once and
-        announces its recovery. A camera that stays online but stops
-        producing fresh frames counts as stalled - frozen feeds must not
-        pass for monitoring.
+        Outages shorter than the grace period are ignored, and a sustained
+        one warns exactly once; the recovery is only announced once health
+        has held for _recover_hold(), so a source that reconnects and drops
+        again is one warning rather than a notification per cycle. A camera
+        that stays online but stops producing fresh frames counts as stalled
+        - frozen feeds must not pass for monitoring.
         """
         while True:
             now = time.monotonic()
@@ -159,18 +164,38 @@ class Watchdog:
         down_message: str,
         up_message: str,
     ) -> bool:
-        if healthy:
-            self._down_since.pop(key, None)
-            if key in self._warned:
-                self._warned.discard(key)
-                await self._warn(monitor, up_message, recovered=True)
-            return False
-        since = self._down_since.setdefault(key, now)
-        if now - since >= grace and key not in self._warned:
+        if not healthy:
+            self._healthy_since.pop(key, None)
+            down_since = self._down_since.setdefault(key, now)
+            if now - down_since < grace or key in self._warned:
+                return False
             self._warned.add(key)
             await self._warn(monitor, down_message)
             return True
+        healthy_since = self._healthy_since.setdefault(key, now)
+        if key not in self._warned:
+            self._down_since.pop(key, None)
+            if now - healthy_since >= FLAP_HOLD_MAX_S:
+                self._flaps.pop(key, None)
+            return False
+        if now - healthy_since < self._recover_hold(key):
+            return False
+        self._warned.discard(key)
+        self._down_since.pop(key, None)
+        self._flaps[key] = self._flaps.get(key, 0) + 1
+        await self._warn(monitor, up_message, recovered=True)
         return False
+
+    def _recover_hold(self, key: str) -> float:
+        """How long a condition must stay healthy before its recovery is announced.
+
+        Every recovery doubles what the next one has to prove, up to
+        FLAP_HOLD_MAX_S, so a source that keeps dropping and reconnecting is
+        announced once for the whole unstable episode instead of on every
+        cycle. The requirement lapses once the condition has held for the
+        maximum without faulting again.
+        """
+        return min(FLAP_HOLD_MAX_S, RECOVER_HOLD_S * 2 ** self._flaps.get(key, 0))
 
     async def _warn(self, monitor: dict[str, Any], message: str, recovered: bool = False) -> None:
         self._engine.emit({"event": "warning", "monitor_id": monitor["id"], "message": message, "recovered": recovered})

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -242,6 +242,7 @@ async def test_watchdog_and_failed_action(monkeypatch) -> None:
     watchdog.WATCH_TICK_S = 0.05
     watchdog.OFFLINE_GRACE_S = 0.2
     watchdog.ACT_RETRY_S = 0.01
+    monkeypatch.setattr(watchdog, "RECOVER_HOLD_S", 0.1)
     monkeypatch.setattr(engine_module, "STATE_TICK_S", 0.05)
     monkeypatch.setattr(engine_module, "REATTACH_EVERY_TICKS", 1)
     platform = FakePlatform(infer_s=0.02, failing=True)
@@ -277,6 +278,7 @@ async def test_watchdog_restarts_stalled_camera_after_fresh_inference(monkeypatc
 
     monkeypatch.setattr(watchdog, "WATCH_TICK_S", 0.02)
     monkeypatch.setattr(watchdog, "STALL_GRACE_S", 0.1)
+    monkeypatch.setattr(watchdog, "RECOVER_HOLD_S", 0.1)
     monkeypatch.setattr(engine_module, "STATE_TICK_S", 0.02)
     platform = FakePlatform(infer_s=0.01)
     async with running_engine(platform, camera_fps=[20.0]) as (engine, events):
@@ -299,6 +301,48 @@ async def test_watchdog_restarts_stalled_camera_after_fresh_inference(monkeypatc
             if event.get("event") == "warning" and event["recovered"] and "feed recovered" in event["message"]
         )
         assert any(event.get("event") == "result" for event in events[stalled_index + 1 : recovered_index])
+
+
+async def test_flapping_camera_warns_once_per_outage(monkeypatch) -> None:
+    from printguard.engine import engine as engine_module
+
+    monkeypatch.setattr(watchdog, "WATCH_TICK_S", 0.02)
+    monkeypatch.setattr(watchdog, "OFFLINE_GRACE_S", 0.05)
+    monkeypatch.setattr(watchdog, "RECOVER_HOLD_S", 0.2)
+    monkeypatch.setattr(engine_module, "STATE_TICK_S", 0.02)
+    platform = FakePlatform(infer_s=0.02)
+    async with running_engine(platform, camera_fps=[10.0]) as (engine, events):
+        monitor_id = next(iter(engine.monitors))
+        await engine.handle({"cmd": "settings.update", "patch": {"notifiers": {"ntfy": {"url": "http://ntfy/topic"}}}})
+        await engine.handle({"cmd": "monitor.update", "id": monitor_id, "patch": {"notify": True}})
+        camera = next(iter(engine.cameras.values()))
+
+        def warnings(recovered: bool) -> list[dict]:
+            return [e for e in events if e.get("event") == "warning" and e["recovered"] is recovered]
+
+        async def hold_source(online: bool, seconds: float) -> None:
+            while camera.frame_source is None:
+                await asyncio.sleep(0.01)
+            camera.frame_source.online = online
+            await asyncio.sleep(seconds)
+
+        for _ in range(5):
+            await hold_source(False, 0.15)
+            await hold_source(True, 0.1)
+
+        assert len(warnings(False)) == 1, f"a reconnecting camera warned {len(warnings(False))} times about one episode"
+        assert not warnings(True), "recovery was announced while the camera was still flapping"
+        assert len(platform.http_calls) == 1, f"flapping pushed {len(platform.http_calls)} notifications"
+
+        await hold_source(True, 0.5)
+        assert len(warnings(True)) == 1, "sustained recovery was never announced"
+        assert len(platform.http_calls) == 2, "recovery should push exactly once"
+
+        await hold_source(False, 0.15)
+        await hold_source(True, 0.3)
+        assert len(warnings(True)) == 1, "a camera that fails again must settle for longer before recovery is announced"
+        await hold_source(True, 0.6)
+        assert len(warnings(True)) == 2, "recovery was never announced after the longer settled period"
 
 
 async def test_protocol_surfaces_errors_and_filters_settings() -> None:


### PR DESCRIPTION
Reported in #102: notifications arriving in a stream about a camera connecting and
reconnecting, with the monitor's cooldown raised to 300s making no difference.

It is not an ntfy problem, and the cooldown was never going to help. `cooldown_s` gates
defect alerts in `on_score`; the watchdog's health path pushes through `_warn` with nothing
in front of it. The health path also cleared its warned state on the first healthy tick, so
every reconnection announced itself: an "offline" push, then a "back" push, then the same
pair again on the next drop. The watchdog's own `restart_camera` on the down edge guarantees
that offline-to-online transition, so a marginal feed pushed a pair per cycle, unbounded, on
every channel. I reproduced it in a test: five drop-outs over one and a half seconds
produced ten warnings and ten pushes.

The fix is hysteresis on the recovery side, which is the standard treatment for flapping
(Alertmanager's `keep_firing_for`): a recovery is only announced once health has held for
`RECOVER_HOLD_S`, and each announced recovery doubles what the next one must hold for, up to
fifteen minutes, lapsing once the condition has been healthy throughout. The ladder is
self-limiting, since reaching the cap is itself proof of stability and resets the count.

Outages are never delayed, only recoveries, so nothing about failing loud changes: you still
hear about a camera going down within the grace period, and the dashboard's live `online`
state is untouched.

- `tests/test_engine.py::test_flapping_camera_warns_once_per_outage` pins both halves: one
  warning and one push for a flapping episode, and a longer settled period demanded after
  each recovery.
- No version bump here, that lives on the release branch.
