### PR TITLE
Ship a current Intel driver in the -intel image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,15 +24,19 @@ jobs:
         include:
           - name: standard
             extra: ""
-            gpu_runtime_packages: ""
+            gpu_runtime_debs: ""
             gpu_visible_devices: ""
           - name: Intel
             extra: ""
-            gpu_runtime_packages: intel-opencl-icd ocl-icd-libopencl1
+            gpu_runtime_debs: >-
+              https://github.com/intel/intel-graphics-compiler/releases/download/v2.38.2/intel-igc-core-2_2.38.2+22051_amd64.deb
+              https://github.com/intel/intel-graphics-compiler/releases/download/v2.38.2/intel-igc-opencl-2_2.38.2+22051_amd64.deb
+              https://github.com/intel/compute-runtime/releases/download/26.27.39122.11/libigdgmm12_22.10.0_amd64.deb
+              https://github.com/intel/compute-runtime/releases/download/26.27.39122.11/intel-opencl-icd_26.27.39122.11-0_amd64.deb
             gpu_visible_devices: ""
           - name: NVIDIA
             extra: --extra nvidia
-            gpu_runtime_packages: ""
+            gpu_runtime_debs: ""
             gpu_visible_devices: all
     steps:
       - uses: actions/checkout@v4
@@ -43,7 +47,7 @@ jobs:
           push: false
           build-args: |
             INFERENCE_EXTRA=${{ matrix.extra }}
-            GPU_RUNTIME_PACKAGES=${{ matrix.gpu_runtime_packages }}
+            GPU_RUNTIME_DEBS=${{ matrix.gpu_runtime_debs }}
             NVIDIA_VISIBLE_DEVICES=${{ matrix.gpu_visible_devices }}
           cache-from: type=gha,scope=${{ matrix.name }}
           cache-to: type=gha,mode=max,scope=${{ matrix.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,19 +50,23 @@ jobs:
             platforms: linux/amd64,linux/arm64
             suffix: ""
             extra: ""
-            gpu_runtime_packages: ""
+            gpu_runtime_debs: ""
             gpu_visible_devices: ""
           - name: Intel
             platforms: linux/amd64
             suffix: -intel
             extra: ""
-            gpu_runtime_packages: intel-opencl-icd ocl-icd-libopencl1
+            gpu_runtime_debs: >-
+              https://github.com/intel/intel-graphics-compiler/releases/download/v2.38.2/intel-igc-core-2_2.38.2+22051_amd64.deb
+              https://github.com/intel/intel-graphics-compiler/releases/download/v2.38.2/intel-igc-opencl-2_2.38.2+22051_amd64.deb
+              https://github.com/intel/compute-runtime/releases/download/26.27.39122.11/libigdgmm12_22.10.0_amd64.deb
+              https://github.com/intel/compute-runtime/releases/download/26.27.39122.11/intel-opencl-icd_26.27.39122.11-0_amd64.deb
             gpu_visible_devices: ""
           - name: NVIDIA
             platforms: linux/amd64
             suffix: -nvidia
             extra: --extra nvidia
-            gpu_runtime_packages: ""
+            gpu_runtime_debs: ""
             gpu_visible_devices: all
     permissions:
       contents: read
@@ -93,7 +97,7 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
             INFERENCE_EXTRA=${{ matrix.extra }}
-            GPU_RUNTIME_PACKAGES=${{ matrix.gpu_runtime_packages }}
+            GPU_RUNTIME_DEBS=${{ matrix.gpu_runtime_debs }}
             NVIDIA_VISIBLE_DEVICES=${{ matrix.gpu_visible_devices }}
           provenance: mode=max
           sbom: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,20 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 
 ## [2.4.0] - 2026-08-15
 
+### Fixed
+
+- **The `latest-intel` image could not use most Intel GPUs.** It carried Debian's Intel GPU
+  driver, which is from late 2022 and predates Meteor Lake, Lunar Lake, Arrow Lake and
+  Battlemage, so OpenVINO was handed no GPU on that hardware and inference quietly stayed on
+  the CPU. The image now carries Intel's own current runtime, covering Arc, Battlemage and
+  every iGPU from Tiger Lake (11th gen) onwards. Intel publishes no current driver for Gen8
+  to Gen11 graphics, so a pre-Tiger-Lake iGPU stays on the OpenVINO CPU path. Thanks for the
+  report.
+- **The compute readout now names the hardware, not the provider.** `intel openvino` meant
+  either the GPU or the processor; it now reads `intel gpu` or `intel cpu`, and the log lists
+  what the providers offered at start, so a GPU that was never handed over is visible rather
+  than guessed at.
+
 ## [2.3.12] - 2026-08-12
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ COPY web/ ./
 COPY docs/assets/ ../docs/assets/
 RUN npm run build
 
-FROM python:3.13-slim-bookworm AS deps
+FROM python:3.13-slim-trixie AS deps
 ARG INFERENCE_EXTRA
 COPY --from=ghcr.io/astral-sh/uv:0.11.32 /uv /usr/local/bin/uv
 WORKDIR /app
@@ -22,11 +22,17 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 RUN apt-get update && apt-get install -y --no-install-recommends binutils \
     && find .venv \( -name '*.cpython-*.so' -o -name '*.abi3.so' \) -exec strip --strip-debug {} +
 
-FROM python:3.13-slim-bookworm
-ARG GPU_RUNTIME_PACKAGES
+FROM python:3.13-slim-trixie
+ARG GPU_RUNTIME_DEBS
 ARG NVIDIA_VISIBLE_DEVICES
 WORKDIR /app
-RUN if [ -n "$GPU_RUNTIME_PACKAGES" ]; then apt-get update && apt-get install -y --no-install-recommends $GPU_RUNTIME_PACKAGES; fi \
+RUN if [ -n "$GPU_RUNTIME_DEBS" ]; then \
+        apt-get update \
+        && apt-get install -y --no-install-recommends curl \
+        && curl -fsSL --remote-name-all --output-dir /tmp $GPU_RUNTIME_DEBS \
+        && apt-get install -y --no-install-recommends /tmp/*.deb \
+        && apt-get purge -y curl && apt-get autoremove -y && rm /tmp/*.deb; \
+    fi \
     && rm -rf /var/lib/apt/lists/*
 COPY --from=deps /app/.venv .venv
 COPY --from=mediamtx /mediamtx /usr/local/bin/mediamtx

--- a/docs/hardware.md
+++ b/docs/hardware.md
@@ -42,14 +42,14 @@ only in the acceleration runtime they bundle.
 | Tag | Platforms | Adds | Use it when |
 |---|---|---|---|
 | `latest` | `amd64`, `arm64` | Nothing. Smallest download | Default choice, including Raspberry Pi 4/5 |
-| `latest-intel` | `amd64` | Intel GPU compute runtime | You pass `--device /dev/dri` for an Intel iGPU or Arc card |
+| `latest-intel` | `amd64` | Intel's current GPU compute runtime | You pass `--device /dev/dri` for an Arc card, or an iGPU from Tiger Lake (11th gen) onwards |
 | `latest-nvidia` | `amd64` | TensorRT RTX execution provider and the CUDA 12 runtime | You have an RTX 30 series or newer and the NVIDIA Container Toolkit |
 
 Versioned tags exist alongside them: `X.Y.Z`, `X.Y`, and the same three suffixes, for
 example `2.3.8-intel`. Pin `X.Y` if you want patch updates without surprises.
 
 > [!NOTE]
-> The Intel GPU compute runtime is roughly 290 MB of compiler and driver libraries that do
+> The Intel GPU compute runtime is roughly 370 MB of compiler and driver libraries that do
 > nothing unless a GPU device is passed in, which is why it lives in its own tag rather
 > than the default image. Intel **CPU** acceleration through OpenVINO is in the standard
 > `amd64` image and needs no extra tag.
@@ -62,7 +62,7 @@ flowchart TD
     arch -- "arm64, e.g. Raspberry Pi" --> std["latest"]
     arch -- "amd64" --> gpu{"Passing a GPU to the container?"}
     gpu -- "No" --> std2["latest<br/>OpenVINO uses the Intel CPU path"]
-    gpu -- "Intel iGPU or Arc, /dev/dri" --> intel["latest-intel"]
+    gpu -- "Intel Arc, or an iGPU from Tiger Lake on, /dev/dri" --> intel["latest-intel"]
     gpu -- "NVIDIA RTX 30+ with Container Toolkit" --> nvidia["latest-nvidia"]
 ```
 
@@ -133,6 +133,22 @@ Compose:
 On Unraid, set the repository to `ghcr.io/oliverbravery/printguard:latest-intel` and add
 the template's **Intel GPU** device.
 
+The image carries Intel's own current compute runtime rather than the distribution's: it
+covers Arc and Battlemage cards, and every iGPU from Tiger Lake (11th gen) onwards. Intel
+ships no current driver for Gen8 to Gen11 graphics, so a pre-Tiger-Lake iGPU has no GPU
+path and inference stays on the OpenVINO CPU path.
+
+**compute** in the header names the hardware in use, so it reads `intel gpu` once the GPU
+is running the model, and `intel cpu` while OpenVINO is on the processor. The log lists
+everything the providers offered at start:
+
+```
+execution providers offer: Intel GPU, Intel CPU
+```
+
+A GPU missing from that line is one the driver never handed over: check that the device is
+passed in with `--device /dev/dri` and that the tag ends in `-intel`.
+
 ## NVIDIA GPU
 
 Needs an RTX 30 series card or newer and the
@@ -164,8 +180,9 @@ PrintGuard logs which provider is unavailable and keeps running on the CPU.
 
 ## Reading and pinning the runtime
 
-The header's **compute** readout names the active provider, for example `intel openvino` or
-`apple core ml`, and clicking it opens the setting. **Settings → Advanced** offers:
+The header's **compute** readout names the hardware the model is running on, for example
+`intel gpu`, `nvidia gpu` or `apple core ml`, and clicking it opens the setting.
+**Settings → Advanced** offers:
 
 | Setting | Effect |
 |---|---|

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -61,9 +61,9 @@ Find the symptom, apply the fix. Every row links to the page that explains the r
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| An Intel GPU is not used | The standard image leaves the Intel GPU runtime out | Use the `latest-intel` tag *and* pass `--device /dev/dri`. [Intel GPU](hardware.md#intel-gpu) |
+| An Intel GPU is not used | The standard image leaves the Intel GPU runtime out, the render device was not passed in, or the GPU predates Tiger Lake | Use the `latest-intel` tag *and* pass `--device /dev/dri`. **compute** reads `intel gpu` when the GPU is in use, and the log lists what the providers offered at start. [Intel GPU](hardware.md#intel-gpu) |
 | An NVIDIA GPU is not used | Missing Container Toolkit, the container started without the NVIDIA runtime, or the wrong tag | The log names the provider it could not load, then falls back to the CPU. [NVIDIA GPU](hardware.md#nvidia-gpu) |
-| **compute** reads `cpu` on a machine with an accelerator | No compatible provider was usable, so ONNX Runtime fell back | [Execution providers by platform](hardware.md#execution-providers-by-platform) |
+| **compute** names a CPU on a machine with an accelerator | No provider was handed the accelerator, so the model stayed on the processor | [Execution providers by platform](hardware.md#execution-providers-by-platform) |
 | Throughput differs from what you expected | Automatic mode picks whichever runtime benchmarks faster on the host | The choice is logged at start. Pin one in **Settings → Advanced** |
 
 ## Getting logs and diagnostics

--- a/printguard/server/inference.py
+++ b/printguard/server/inference.py
@@ -36,15 +36,8 @@ WINDOWS_PROVIDERS = {
     "QNNExecutionProvider",
     "VitisAIExecutionProvider",
 }
-PROVIDER_LABELS = {
-    "CoreMLExecutionProvider": "Apple Core ML",
-    "MIGraphXExecutionProvider": "AMD GPU",
-    "NvTensorRtRtxExecutionProvider": "NVIDIA GPU",
-    "nv_tensorrt_rtx": "NVIDIA GPU",
-    "OpenVINOExecutionProvider": "Intel OpenVINO",
-    "QNNExecutionProvider": "Qualcomm NPU",
-    "VitisAIExecutionProvider": "AMD NPU",
-}
+DEFAULT_CPU_PROVIDER = "CPUExecutionProvider"
+DEVICE_PRIORITY = ("GPU", "NPU", "CPU")
 REGISTERED_LIBRARIES: set[str] = set()
 logger = logging.getLogger(__name__)
 
@@ -77,6 +70,37 @@ def _register_library(name: str, path: str) -> bool:
         return False
     REGISTERED_LIBRARIES.add(name)
     return True
+
+
+def _device_rank(device: ort.OrtEpDevice) -> tuple[int, bool]:
+    """Orders one provider device by the throughput its hardware can be expected to reach."""
+    return DEVICE_PRIORITY.index(device.device.type.name), device.device.metadata.get("Discrete") != "1"
+
+
+def _execution_devices(devices: list[ort.OrtEpDevice]) -> list[ort.OrtEpDevice]:
+    """Returns the hardware the registered providers offer, fastest first.
+
+    A provider registers one device per piece of hardware it can reach, so a GPU
+    missing from this list is one the host's driver never handed to the provider,
+    which is the difference between a GPU that is unusable and one that is merely
+    slower. ONNX Runtime's own selection policies pick a device without saying which,
+    and OpenVINO's meta devices choose again at inference time, so neither can name
+    the hardware actually in use: the choice is made here instead, where it is named
+    in the `compute` readout and in the log.
+    """
+    return sorted(
+        (
+            device
+            for device in devices
+            if device.ep_name != DEFAULT_CPU_PROVIDER and "ov_meta_device" not in device.ep_metadata
+        ),
+        key=_device_rank,
+    )
+
+
+def _device_label(device: ort.OrtEpDevice) -> str:
+    """Names the hardware behind a provider device, for example `Intel GPU`."""
+    return f"{device.ep_vendor} {device.device.type.name}"
 
 
 def _throughput(model: Model, workers: int) -> float:
@@ -124,47 +148,47 @@ class OnnxInference:
 
     def __init__(self, model_path: Path) -> None:
         self._resources = ExitStack()
-        registered = self._register_plugins()
+        self._register_plugins()
         if sys.platform == "win32":
-            registered += self._register_windows_providers()
+            self._register_windows_providers()
 
         options = ort.SessionOptions()
         options.intra_op_num_threads = 1
-        if registered:
-            options.set_provider_selection_policy(ort.OrtExecutionProviderDevicePolicy.MAX_PERFORMANCE)
+        devices = _execution_devices(ort.get_ep_devices())
+        if devices:
+            logger.info("execution providers offer: %s", ", ".join(_device_label(device) for device in devices))
+            options.add_provider_for_devices(devices[:1], {})
             self._session = ort.InferenceSession(str(model_path), sess_options=options)
+            self.device = _device_label(devices[0])
         elif "CoreMLExecutionProvider" in ort.get_available_providers():
             providers = [
                 (
                     "CoreMLExecutionProvider",
                     {"ModelFormat": "MLProgram", "MLComputeUnits": "ALL", "RequireStaticInputShapes": "1"},
                 ),
-                "CPUExecutionProvider",
+                DEFAULT_CPU_PROVIDER,
             ]
             self._session = ort.InferenceSession(str(model_path), sess_options=options, providers=providers)
+            self.device = "Apple Core ML"
         else:
             self._session = ort.InferenceSession(
-                str(model_path), sess_options=options, providers=["CPUExecutionProvider"]
+                str(model_path), sess_options=options, providers=[DEFAULT_CPU_PROVIDER]
             )
+            self.device = "ONNX CPU"
 
-        provider = next((name for name in self._session.get_providers() if name in PROVIDER_LABELS), None)
-        self.device = PROVIDER_LABELS.get(provider, "ONNX CPU")
         self._input_name = self._session.get_inputs()[0].name
 
-    def _register_plugins(self) -> int:
+    def _register_plugins(self) -> None:
         _preload_cuda_runtime()
-        registered = 0
         for module_name in PLUGIN_MODULES:
             if importlib.util.find_spec(module_name) is None:
                 continue
             module = importlib.import_module(module_name)
-            if _register_library(module_name, module.get_library_path()):
-                registered += 1
-        return registered
+            _register_library(module_name, module.get_library_path())
 
-    def _register_windows_providers(self) -> int:
+    def _register_windows_providers(self) -> None:
         if sys.getwindowsversion().build < 26100:
-            return 0
+            return
         from winui3.microsoft.windows.applicationmodel.dynamicdependency.bootstrap import InitializeOptions, initialize
         import winui3.microsoft.windows.ai.machinelearning as winml
 
@@ -174,15 +198,12 @@ class OnnxInference:
             for provider in winml.ExecutionProviderCatalog.get_default().find_all_providers()
             if provider.name in WINDOWS_PROVIDERS
         ]
-        registered = 0
         for provider in providers:
             if provider.ready_state != winml.ExecutionProviderReadyState.READY:
                 result = provider.ensure_ready_async().get()
                 if result.status != winml.ExecutionProviderReadyResultState.SUCCESS:
                     continue
-            if _register_library(provider.name, provider.library_path):
-                registered += 1
-        return registered
+            _register_library(provider.name, provider.library_path)
 
     def run(self, tensor: np.ndarray) -> np.ndarray:
         """Returns the model embedding for one preprocessed frame."""

--- a/tests/test_platform.py
+++ b/tests/test_platform.py
@@ -7,12 +7,19 @@ import json
 import threading
 import time
 from pathlib import Path
+from types import SimpleNamespace
 
 import numpy as np
 import pytest
 
 from printguard.engine import vision
-from printguard.server.inference import Inference, _measure_concurrency, _register_library
+from printguard.server.inference import (
+    Inference,
+    _device_label,
+    _execution_devices,
+    _measure_concurrency,
+    _register_library,
+)
 from printguard.server.platform import ServerPlatform
 
 
@@ -58,6 +65,34 @@ async def test_runtimes_agree_on_classification() -> None:
     assert embeddings[0].shape == embeddings[1].shape == (1024,)
     assert classifications[0]["prediction"] == classifications[1]["prediction"]
     assert drift < min(result["margin"] for result in classifications) / 2
+
+
+def _ep_device(ep_name: str, vendor: str, device_type: str, ep_metadata: dict[str, str]) -> SimpleNamespace:
+    """Builds a stand-in for one device an ONNX Runtime provider offers."""
+    return SimpleNamespace(
+        ep_name=ep_name,
+        ep_vendor=vendor,
+        ep_metadata=ep_metadata,
+        device=SimpleNamespace(type=SimpleNamespace(name=device_type), metadata={}),
+    )
+
+
+def test_the_accelerator_a_provider_offers_wins_and_is_the_one_named() -> None:
+    """An Intel image with a working GPU must run on it, and say so.
+
+    OpenVINO offers a CPU path under the same provider name as its GPU, so a GPU
+    that the host's driver never handed over is indistinguishable from one in use
+    unless the hardware behind the provider is what gets ranked and named. Its meta
+    devices pick again at inference time, so neither can stand in for the GPU.
+    """
+    devices = [
+        _ep_device("CPUExecutionProvider", "Microsoft", "CPU", {}),
+        _ep_device("OpenVINOExecutionProvider", "Intel", "CPU", {"ov_device": "CPU"}),
+        _ep_device("OpenVINOExecutionProvider.AUTO", "Intel", "GPU", {"ov_device": "GPU", "ov_meta_device": "AUTO"}),
+        _ep_device("OpenVINOExecutionProvider", "Intel", "GPU", {"ov_device": "GPU"}),
+    ]
+
+    assert [_device_label(device) for device in _execution_devices(devices)] == ["Intel GPU", "Intel CPU"]
 
 
 def test_provider_library_that_cannot_load_leaves_the_cpu(tmp_path: Path) -> None:


### PR DESCRIPTION
Reported in #106: Debian's `intel-opencl-icd` is from late 2022, so OpenVINO enumerated no GPU on anything newer than Alder Lake and inference dropped to the CPU. The image now pins Intel's own current compute runtime and graphics compiler, which needs Debian 13 for glibc.

Device choice is explicit rather than left to ONNX Runtime's policy, so **compute** reads `intel gpu` or `intel cpu` instead of `intel openvino`, and the log lists what the providers offered at start.

No version bump here, that lives on the release branch.