### PR TITLE
Warn when a printer's state cannot be read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,11 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
   path, since Intel publishes no current driver for them.
 - The compute readout names the hardware, so `intel openvino` now reads `intel gpu` or
   `intel cpu`, and the log lists what the providers offered at start.
+- A monitor whose printer reports a state PrintGuard cannot read now warns and says so on its
+  panel. It keeps watching, which is the safe direction, but only an unreachable printer warned
+  before, so a printer stuck in something like OctoPrint's "Connecting" ran inference at the
+  camera's full frame rate with nothing explaining why. A printer that starts reporting again
+  is announced as recovered even if it comes back idle.
 
 ## [2.3.12] - 2026-08-12
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -324,7 +324,10 @@ stateDiagram-v2
 
 The three watchdog conditions are a watched camera going offline, a watched camera staying
 online but producing no fresh frames, since a frozen RTSP feed must not pass for monitoring,
-and a linked printer service becoming unreachable, since defects could no longer pause it.
+and a linked printer whose state cannot be read, whether it is unreachable or reporting
+something the adapter does not recognise. The last one is why the monitor is watching, and
+it means a defect could not pause the print, so it is checked for every enabled monitor
+rather than only for watched ones.
 
 Warnings surface as dashboard toasts and go out through the notification channels, so the
 watchdog suppresses flapping rather than repeating itself. A source that reconnects and drops

--- a/docs/printers.md
+++ b/docs/printers.md
@@ -42,7 +42,9 @@ print or cancels it.
 
 Linked printers report job name, progress and state on every monitor that uses them, and they
 gate inference. A printer that positively reports "not printing" stands its monitors down, so
-an idle printer costs nothing. Losing contact with a printer never stands monitoring down. See
+an idle printer costs nothing. Losing contact with a printer never stands monitoring down, and
+neither does a state the adapter cannot read, so a monitor left watching an apparently idle
+printer warns and says which state it is getting. See
 [failing safely](architecture.md#failing-safely).
 
 ## Supported print services

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -34,6 +34,7 @@ Find the symptom, apply the fix. Every row links to the page that explains the r
 | Camera is **offline** in the registry but the feed works elsewhere | Wrong scheme or path, or a source that needs credentials in the URL | Re-test the URL. RTSP sources are pulled by MediaMTX, so it must reach them too |
 | **This device** camera will not start | Browsers only allow camera access on secure pages | Serve the hub over HTTPS or open it on `localhost`. [Deployment](deployment.md) covers both |
 | Feed plays but the risk score never moves | The monitor is in standby because its printer positively reports "not printing" | This is by design. See [failing safely](architecture.md#failing-safely) |
+| Risk score keeps moving with the printer sitting idle | The service reports a state PrintGuard cannot read, so the monitor cannot be stood down | This is by design, and the monitor's panel says which state it is getting. A warning goes out once the state has been unreadable for a few seconds |
 | Video is smooth for one camera and choppy for several | The host's sustainable capacity is shared across cameras | Check the **capacity** and **latency** readouts, then [Hardware](hardware.md#how-much-hardware-you-need) |
 | **Capacity** fell sharply after upgrading to 2.3.7 | 2.3.7 ran inference on two workers on hosts that could sustain many more | Fixed in 2.3.8, which measures the worker count. The startup log line `inference ready:` reports what it settled on |
 

--- a/printguard/engine/watchdog.py
+++ b/printguard/engine/watchdog.py
@@ -91,19 +91,32 @@ class Watchdog:
             await asyncio.sleep(DEVICE_POLL_S)
 
     async def watch_health(self) -> None:
-        """Warns when a watched camera or printer service drops out.
+        """Warns when a watched camera drops out or a printer stops reporting.
 
         Outages shorter than the grace period are ignored, and a sustained
         one warns exactly once; the recovery is only announced once health
         has held for _recover_hold(), so a source that reconnects and drops
         again is one warning rather than a notification per cycle. A camera
         that stays online but stops producing fresh frames counts as stalled
-        - frozen feeds must not pass for monitoring.
+        - frozen feeds must not pass for monitoring. Printer health is checked
+        for every enabled monitor, since a printer that reports nothing usable
+        is the reason its monitor is watching in the first place.
         """
         while True:
             now = time.monotonic()
             for monitor in list(self._engine.monitors.values()):
                 mid = monitor["id"]
+                printer = self._engine.printers.get(monitor["printer_id"]) if monitor.get("printer_id") else None
+                if monitor.get("enabled") and printer is not None:
+                    await self._edge(
+                        f"device:{mid}",
+                        printer.online,
+                        now,
+                        OFFLINE_GRACE_S,
+                        monitor,
+                        f"Cannot tell whether the printer for '{monitor['name']}' is printing, so it keeps watching and a defect cannot pause the print",
+                        f"Printer for '{monitor['name']}' is reporting its state again",
+                    )
                 camera = self._engine.cameras.get(monitor["camera_id"]) if monitor["camera_id"] else None
                 if not monitor_watching(monitor, self._engine.printers) or camera is None:
                     self._online_since.pop(mid, None)
@@ -140,18 +153,6 @@ class Watchdog:
                 )
                 if stalled:
                     await self._engine.restart_camera(camera)
-                printer = self._engine.printers.get(monitor["printer_id"]) if monitor.get("printer_id") else None
-                if printer is not None:
-                    reachable = (printer.device_state or {}).get("status") != "offline"
-                    await self._edge(
-                        f"device:{mid}",
-                        reachable,
-                        now,
-                        OFFLINE_GRACE_S,
-                        monitor,
-                        f"Printer service for '{monitor['name']}' is unreachable, so defects cannot pause this print",
-                        f"Printer service for '{monitor['name']}' is reachable again",
-                    )
             await asyncio.sleep(WATCH_TICK_S)
 
     async def _edge(

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -180,6 +180,30 @@ async def test_standby_gating() -> None:
     assert resumed > 0, "inference did not resume when printing started"
 
 
+async def test_unreadable_printer_state_keeps_watching_and_warns(monkeypatch) -> None:
+    monkeypatch.setattr(watchdog, "DEVICE_POLL_S", 0.05)
+    monkeypatch.setattr(watchdog, "WATCH_TICK_S", 0.05)
+    monkeypatch.setattr(watchdog, "OFFLINE_GRACE_S", 0.2)
+    monkeypatch.setattr(watchdog, "RECOVER_HOLD_S", 0.1)
+    platform = FakePlatform(infer_s=0.02)
+    platform.device_status = "Detecting serial connection"
+    async with running_engine(platform, camera_fps=[10.0]) as (engine, events):
+        monitor_id = next(iter(engine.monitors))
+        printer_id = await _register_printer(engine)
+        await engine.handle({"cmd": "monitor.update", "id": monitor_id, "patch": {"printer_id": printer_id}})
+        await asyncio.sleep(1.0)
+        assert engine.printers.get(printer_id).device_state["status"] == "unknown"
+        assert engine.state_event()["monitors"][0]["watching"], "a state the adapter cannot read must keep watching"
+        assert any(e.get("event") == "result" for e in events), "watching monitor did not infer"
+        warnings = [e for e in events if e.get("event") == "warning" and not e["recovered"]]
+        assert any("Cannot tell whether the printer" in w["message"] for w in warnings), "unreadable printer state did not warn"
+
+        platform.device_status = "Operational"
+        await asyncio.sleep(1.0)
+        recoveries = [e for e in events if e.get("event") == "warning" and e["recovered"]]
+        assert any("reporting its state again" in r["message"] for r in recoveries), "recovery was never announced"
+
+
 async def test_restored_camera_attachment_is_single_flight(monkeypatch) -> None:
     from fakes import FakeSource
     from printguard.engine import engine as engine_module

--- a/web/src/components/DetailPanel.tsx
+++ b/web/src/components/DetailPanel.tsx
@@ -154,6 +154,12 @@ export function DetailPanel({ monitor }: { monitor: Monitor }) {
                 standby, printer is {printer?.device_state?.status ?? "not printing"}, inference resumes when it prints
               </p>
             )}
+            {monitor.enabled && monitor.watching !== false && printer && !printer.online && (
+              <p className="mono text-[0.7rem] text-text-2">
+                watching, the printer reports {printer.device_state?.status ?? "nothing yet"}, so inference runs until it says it is
+                not printing
+              </p>
+            )}
             <label className="block">
               <span className="label block mb-1">Camera</span>
               <select className="field" value={monitor.camera_id} onChange={(e) => updateMonitor(monitor.id, { camera_id: e.target.value })}>


### PR DESCRIPTION
Reported in #109.

A monitor only stands down when its printer positively reports a non-printing state, but the health check only warned when that printer was `offline`. One reporting `unknown`, like an OctoPrint printer sitting in "Connecting", inferred at the camera's full frame rate with nothing saying why.

The check now runs off `Printer.online`, which covers both, and off every enabled monitor rather than only watched ones, so a printer that comes back idle is still announced as recovered. The monitor's panel says which state it is getting.