### PR TITLE
Walk a new install through how PrintGuard works

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 - Four come as standard. Picture in picture floats a camera above your other windows, alert
   sounds plays a horn when a defect is caught, progress reports sends a tally of a print through
   your alert channels, and Spotify puts the current cover behind the dashboard.
+- A five-page walkthrough on first load, covering what PrintGuard does, cameras and printers,
+  monitors, and when inference runs and when it stands down. It only appears on an install with no
+  monitors yet, and the full guide stays behind the ? in the header.
 - A Glass theme, alongside System, Light and Dark. The panels frost over whatever is behind
   them, which is what the Spotify plugin's cover shows through. Picking it drops out two
   sliders for how clear the panels are and how light or dark, and text takes whichever colour

--- a/web/src/components/Dashboard.tsx
+++ b/web/src/components/Dashboard.tsx
@@ -8,6 +8,7 @@ import { DemoDialog } from "./DemoDialog";
 import { DetailPanel } from "./DetailPanel";
 import { GettingStarted } from "./GettingStarted";
 import { GuideDialog } from "./GuideDialog";
+import { IntroDialog } from "./IntroDialog";
 import { Header, MobileActionBar } from "./Header";
 import { MonitorDialog } from "./MonitorDialog";
 import { MonitorTile } from "./MonitorTile";
@@ -111,6 +112,7 @@ export function Dashboard() {
       {dialog === "settings" && <SettingsDialog />}
       {dialog === "update" && <UpdateDialog />}
       {dialog === "guide" && <GuideDialog />}
+      {dialog === "intro" && <IntroDialog />}
       {dialog === "report" && <ReportDialog />}
       {dialog === "demo" && <DemoDialog />}
       {detail && <DetailPanel monitor={detail} />}

--- a/web/src/components/GettingStarted.tsx
+++ b/web/src/components/GettingStarted.tsx
@@ -114,9 +114,9 @@ export function GettingStarted() {
         </ol>
         <button
           className="mt-5 text-xs text-text-2 underline transition-colors hover:text-accent"
-          onClick={() => openDialog("guide")}
+          onClick={() => openDialog("intro")}
         >
-          New here? Open the guide →
+          New here? How PrintGuard works →
         </button>
       </div>
     </div>

--- a/web/src/components/GuideDialog.tsx
+++ b/web/src/components/GuideDialog.tsx
@@ -5,16 +5,19 @@ import { Dialog } from "./Dialog";
 const REPO = "https://github.com/oliverbravery/PrintGuard";
 const MODEL = "https://github.com/oliverbravery/Edge-FDM-Fault-Detection";
 
-function GuideEntry({ section }: { section: GuideSection }) {
+export function GuideEntry({ section, lead }: { section: GuideSection; lead?: boolean }) {
   const openDialog = useStore((s) => s.openDialog);
   const { action } = section;
   return (
     <section className="reveal">
       <div className="mb-1.5 flex items-center gap-2.5">
         <span className={`led ${section.led}`} />
-        <h3 className="display text-sm font-semibold tracking-[0.14em]">{section.title}</h3>
+        <h3 className={lead ? "display text-base font-bold" : "display text-sm font-semibold tracking-[0.14em]"}>
+          {section.title}
+        </h3>
       </div>
-      <p className="text-[0.84rem] leading-relaxed text-text-1">{section.body}</p>
+      <p className={`leading-relaxed text-text-1 ${lead ? "text-sm" : "text-[0.84rem]"}`}>{section.body}</p>
+      {section.visual && <div className="mt-3">{section.visual}</div>}
       {action && (
         <button className="btn mt-2.5" onClick={() => openDialog(action.dialog)}>
           {action.label} →
@@ -32,8 +35,8 @@ export function GuideDialog() {
     <Dialog title="Guide" size="wide" onClose={() => openDialog(null)}>
       <div className="space-y-6">
         <p className="text-sm text-text-1">
-          PrintGuard catches print failures for you. Here's what everything means and what you can do
-          Use a section's action to jump straight in.
+          What everything on the dashboard means, and what you can do with it. Use a section's action
+          to jump straight in.
         </p>
         {sections.map((section) => (
           <GuideEntry key={section.id} section={section} />

--- a/web/src/components/IntroDialog.tsx
+++ b/web/src/components/IntroDialog.tsx
@@ -1,0 +1,41 @@
+import { useState } from "react";
+import { INTRO } from "../guide";
+import { useStore } from "../store";
+import { Dialog } from "./Dialog";
+import { GuideEntry } from "./GuideDialog";
+
+export function IntroDialog() {
+  const [page, setPage] = useState(0);
+  const openDialog = useStore((s) => s.openDialog);
+  const close = () => openDialog(null);
+  const last = page === INTRO.length - 1;
+  return (
+    <Dialog title="How PrintGuard works" onClose={close}>
+      <div className="space-y-5">
+        <div aria-live="polite" className="sm:min-h-[13rem]">
+          <GuideEntry key={INTRO[page].id} section={INTRO[page]} lead />
+        </div>
+        <footer className="hairline flex items-center gap-2 pt-4">
+          <div aria-hidden className="flex flex-1 items-center gap-1.5">
+            {INTRO.map((entry, i) => (
+              <span key={entry.id} className={`h-1.5 w-4 rounded-full ${i === page ? "bg-accent" : "bg-ink-3"}`} />
+            ))}
+          </div>
+          {page > 0 && (
+            <button className="btn" onClick={() => setPage(page - 1)}>
+              Back
+            </button>
+          )}
+          <button className="btn" onClick={close}>
+            {last ? "Close" : "Skip"}
+          </button>
+          {!last && (
+            <button className="btn btn-primary" onClick={() => setPage(page + 1)}>
+              Next →
+            </button>
+          )}
+        </footer>
+      </div>
+    </Dialog>
+  );
+}

--- a/web/src/guide.tsx
+++ b/web/src/guide.tsx
@@ -11,9 +11,105 @@ export interface GuideSection {
   led: string;
   title: string;
   body: ReactNode;
+  visual?: ReactNode;
   action?: { label: string; dialog: DialogKind };
   hubOnly?: boolean;
 }
+
+const STEPS = ["Camera", "Score every frame", "Pause and alert"];
+
+const WATCH_STATES: { led: string; when: string; then: string }[] = [
+  { led: "led-on", when: "Printing, or no printer linked", then: "Watching, every frame scored" },
+  { led: "led-off", when: "Positively idle, paused or errored", then: "Standby, nothing scored" },
+  { led: "led-warn", when: "A dropped camera, a frozen feed, or a printer state it cannot read", then: "Keeps watching, and warns you" },
+];
+
+export const INTRO: GuideSection[] = [
+  {
+    id: "what",
+    led: "led-infer",
+    title: "What PrintGuard does",
+    body: (
+      <>
+        A vision model running on your own hardware scores every frame from your printer camera. When
+        a defect holds it pauses or cancels the print and sends you a snapshot. No frame ever leaves
+        your network.
+      </>
+    ),
+    visual: (
+      <div className="flex flex-wrap items-center gap-2">
+        {STEPS.map((step, i) => (
+          <span key={step} className="flex items-center gap-2">
+            {i > 0 && <span className="text-text-2">·</span>}
+            <span className="chip">{step}</span>
+          </span>
+        ))}
+      </div>
+    ),
+  },
+  {
+    id: "sources",
+    led: "led-on",
+    title: "Cameras and printers",
+    body: (
+      <>
+        A camera is any video source PrintGuard can read, so a USB device or an RTSP, MJPEG or WebRTC
+        stream. A printer is optional, and connecting one lets PrintGuard read whether it is printing
+        and stop it when something goes wrong.
+      </>
+    ),
+  },
+  {
+    id: "monitors",
+    led: "led-infer",
+    title: "Monitors are what you tune",
+    body: (
+      <>
+        A monitor binds one camera to one printer and carries the alert threshold, how many detections
+        in a row count as a defect, and what happens when one holds. Everything is set per monitor
+        from its detail panel.
+      </>
+    ),
+  },
+  {
+    id: "watching",
+    led: "led-warn",
+    title: "When inference runs",
+    body: (
+      <>
+        Only a printer that positively reports it is not printing stands a monitor down, so an idle
+        printer costs you nothing. Everything else keeps watching, which is why losing a camera or a
+        printer never leaves a print unwatched.
+      </>
+    ),
+    visual: (
+      <ul className="space-y-2">
+        {WATCH_STATES.map((state) => (
+          <li key={state.led} className="flex gap-3 rounded border border-line-0 bg-ink-0/40 px-3.5 py-2.5">
+            <span className={`led ${state.led} mt-[0.4rem]`} />
+            <div className="min-w-0">
+              <div className="text-sm text-text-0">{state.when}</div>
+              <div className="text-xs leading-relaxed text-text-2">{state.then}</div>
+            </div>
+          </li>
+        ))}
+      </ul>
+    ),
+  },
+  {
+    id: "start",
+    led: "led-on",
+    title: "Start watching",
+    body: (
+      <>
+        Register a camera, then add a monitor binding it. Connect a printer and a notification channel
+        such as ntfy or Telegram for the full net. The rest of the guide sits behind the ? in the
+        header.
+      </>
+    ),
+    action: { label: "Register a camera", dialog: "cameras" },
+  },
+];
 
 export const GUIDE: GuideSection[] = [
   {
@@ -92,9 +188,7 @@ export const GUIDE: GuideSection[] = [
         Every frame is scored against failure prototypes. <strong>Alert threshold</strong> sets how
         high that score must reach, <strong>sensitivity</strong> widens or narrows the margin, and a
         defect must hold for a number of <strong>consecutive detections</strong> before PrintGuard
-        acts. <strong>On sustained defect</strong> chooses nothing, pause or cancel, and{" "}
-        <strong>cooldown</strong> is the quiet window afterwards. Tune these per monitor from its
-        detail panel.
+        acts. Tune it all per monitor from its detail panel.
       </>
     ),
   },
@@ -161,11 +255,9 @@ export const GUIDE: GuideSection[] = [
     body: (
       <>
         Add a panel to the dashboard or a job on the hub, from the catalogue or any GitHub repo.
-        Plugins are third-party code, so they run in a sandbox with only what you grant them. One
-        can put a picture behind the dashboard, which the <strong>Glass</strong> theme shows through
-        the panels.{" "}
-        <strong>Picture in picture</strong>, <strong>Alert sounds</strong> and <strong>Progress reports</strong>{" "}
-        come as standard.{" "}
+        Plugins are third-party code, so they run in a sandbox with only what you grant them.{" "}
+        <strong>Picture in picture</strong>, <strong>Alert sounds</strong>, <strong>Progress reports</strong>{" "}
+        and <strong>Spotify</strong> come as standard.{" "}
         <a className={link} href={docs("plugins.md")} target="_blank" rel="noreferrer">
           Writing one ↗
         </a>
@@ -191,8 +283,7 @@ export const GUIDE: GuideSection[] = [
     body: (
       <>
         Report a bug from the <BugIcon className="inline h-[1.15em] w-[1.15em] align-[-0.2em]" /> chip in the header,
-        anonymously, no account needed. Describe what happened, attach screenshots if they help, and optionally
-        leave an email for follow-up. A diagnostics bundle goes with it, with every credential stripped and no
+        anonymously, no account needed. A diagnostics bundle goes with it, with every credential stripped and no
         camera frames. Download the same bundle from that dialog to read it or send it somewhere else yourself.
       </>
     ),

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -64,9 +64,15 @@ function modeFromUrl(): Mode | null {
 }
 
 const DEMO_SEEN_KEY = "pg.demo.seen";
+const INTRO_SEEN_KEY = "pg.intro.seen";
 
-function demoNoticeDue(mode: Mode | null): boolean {
-  return mode === "local" && !localStorage.getItem(DEMO_SEEN_KEY);
+function introDue(monitorCount: number): boolean {
+  return monitorCount === 0 && !localStorage.getItem(INTRO_SEEN_KEY);
+}
+
+function firstRunDialog(mode: Mode | null, monitorCount: number): DialogKind {
+  if (mode === "local" && !localStorage.getItem(DEMO_SEEN_KEY)) return "demo";
+  return introDue(monitorCount) ? "intro" : null;
 }
 
 export interface Toast {
@@ -75,7 +81,7 @@ export interface Toast {
   text: string;
 }
 
-export type DialogKind = "cameras" | "printers" | "monitor" | "settings" | "update" | "guide" | "report" | "demo" | null;
+export type DialogKind = "cameras" | "printers" | "monitor" | "settings" | "update" | "guide" | "intro" | "report" | "demo" | null;
 export type SettingsTabId = "appearance" | "alerts" | "plugins" | "mqtt" | "updates" | "api" | "advanced";
 
 interface PgStore {
@@ -407,6 +413,7 @@ export const useStore = create<PgStore>((set, get) => {
         }
         const cleared = had && Object.keys(optimistic).length === 0;
         const arriving = get().phase !== "ready";
+        const firstRun = arriving ? firstRunDialog(get().mode, server.monitors.length) : null;
         const engine = Object.keys(optimistic).length ? applyOptimistic(server, optimistic) : server;
         let history = get().history;
         for (const monitor of server.monitors) {
@@ -419,7 +426,7 @@ export const useStore = create<PgStore>((set, get) => {
           optimistic,
           phase: "ready",
           ...(cleared ? { savedAt: Date.now() } : {}),
-          ...(arriving && demoNoticeDue(get().mode) ? { dialog: "demo" as DialogKind } : {}),
+          ...(firstRun ? { dialog: firstRun } : {}),
         });
         if (!resumed && get().mode === "hub") {
           resumed = true;
@@ -696,6 +703,7 @@ export const useStore = create<PgStore>((set, get) => {
 
     openDialog(dialog, focusCameraId = null) {
       get().flushUpdates();
+      if (get().dialog === "intro") localStorage.setItem(INTRO_SEEN_KEY, "1");
       set({
         dialog,
         discovered: null,
@@ -710,7 +718,7 @@ export const useStore = create<PgStore>((set, get) => {
 
     dismissDemo() {
       localStorage.setItem(DEMO_SEEN_KEY, "1");
-      get().openDialog(null);
+      get().openDialog(introDue(get().engine?.monitors.length ?? 0) ? "intro" : null);
     },
 
     openSettings(settingsTab = "alerts") {


### PR DESCRIPTION
Reported in #111.

A new install with no monitors opens a five-page walkthrough, one concept per page, with Skip on every page. It covers what PrintGuard does, cameras and printers, monitors, and when inference runs, with the three watch states laid out so standby, a dropped camera and an unreadable printer state are told apart.

The pages live alongside the existing sections in `web/src/guide.tsx`, so both surfaces read from one file. The full guide stays behind the ? chip, minus the copy the walkthrough now covers.