### PR TITLE
Show the walkthrough to any browser that has not seen it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,8 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
   sounds plays a horn when a defect is caught, progress reports sends a tally of a print through
   your alert channels, and Spotify puts the current cover behind the dashboard.
 - A five-page walkthrough on first load, covering what PrintGuard does, cameras and printers,
-  monitors, and when inference runs and when it stands down. It only appears on an install with no
-  monitors yet, and the full guide stays behind the ? in the header.
+  monitors, and when inference runs and when it stands down. It opens once in every browser that
+  has not seen it, and the full guide stays behind the ? in the header.
 - A Glass theme, alongside System, Light and Dark. The panels frost over whatever is behind
   them, which is what the Spotify plugin's cover shows through. Picking it drops out two
   sliders for how clear the panels are and how light or dark, and text takes whichever colour

--- a/web/src/store.ts
+++ b/web/src/store.ts
@@ -66,13 +66,13 @@ function modeFromUrl(): Mode | null {
 const DEMO_SEEN_KEY = "pg.demo.seen";
 const INTRO_SEEN_KEY = "pg.intro.seen";
 
-function introDue(monitorCount: number): boolean {
-  return monitorCount === 0 && !localStorage.getItem(INTRO_SEEN_KEY);
+function introDue(): boolean {
+  return !localStorage.getItem(INTRO_SEEN_KEY);
 }
 
-function firstRunDialog(mode: Mode | null, monitorCount: number): DialogKind {
+function firstRunDialog(mode: Mode | null): DialogKind {
   if (mode === "local" && !localStorage.getItem(DEMO_SEEN_KEY)) return "demo";
-  return introDue(monitorCount) ? "intro" : null;
+  return introDue() ? "intro" : null;
 }
 
 export interface Toast {
@@ -413,7 +413,7 @@ export const useStore = create<PgStore>((set, get) => {
         }
         const cleared = had && Object.keys(optimistic).length === 0;
         const arriving = get().phase !== "ready";
-        const firstRun = arriving ? firstRunDialog(get().mode, server.monitors.length) : null;
+        const firstRun = arriving ? firstRunDialog(get().mode) : null;
         const engine = Object.keys(optimistic).length ? applyOptimistic(server, optimistic) : server;
         let history = get().history;
         for (const monitor of server.monitors) {
@@ -718,7 +718,7 @@ export const useStore = create<PgStore>((set, get) => {
 
     dismissDemo() {
       localStorage.setItem(DEMO_SEEN_KEY, "1");
-      get().openDialog(introDue(get().engine?.monitors.length ?? 0) ? "intro" : null);
+      get().openDialog(introDue() ? "intro" : null);
     },
 
     openSettings(settingsTab = "alerts") {


### PR DESCRIPTION
Follow-up to #111. I gated the walkthrough on an install having no monitors, so opening a configured hub in a fresh browser showed nothing.

A hub gets opened by people who have never seen it, on a phone or a second machine, and that is the case the walkthrough is for. It now opens once in any browser without the seen flag, which does mean everyone gets it once on updating to 2.4.0.