### PR TITLE
Give the progress bar a track you can see in every theme

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,8 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
   path, since Intel publishes no current driver for them.
 - The compute readout names the hardware, so `intel openvino` now reads `intel gpu` or
   `intel cpu`, and the log lists what the providers offered at start.
+- The Getting Started progress bar is visible in dark and Glass, where its track was taking a
+  colour that all but vanished into the panel behind it.
 - A monitor whose printer reports a state PrintGuard cannot read now warns and says so on its
   panel. It keeps watching, which is the safe direction, but only an unreachable printer warned
   before, so a printer stuck in something like OctoPrint's "Connecting" ran inference at the

--- a/web/src/components/GettingStarted.tsx
+++ b/web/src/components/GettingStarted.tsx
@@ -1,4 +1,5 @@
 import { useStore } from "../store";
+import { Progress } from "./Progress";
 import type { DialogKind } from "../store";
 
 interface Step {
@@ -96,17 +97,7 @@ export function GettingStarted() {
           Register a camera and add a monitor to start watching. Connect a printer and alerts for the
           full safety net.
         </p>
-        <div className="mb-4 flex items-center gap-3">
-          <div className="h-1.5 flex-1 overflow-hidden rounded-full bg-ink-3">
-            <div
-              className="h-full bg-accent transition-[width] duration-500"
-              style={{ width: `${(doneCount / steps.length) * 100}%` }}
-            />
-          </div>
-          <span className="label whitespace-nowrap">
-            {doneCount} of {steps.length}
-          </span>
-        </div>
+        <Progress value={doneCount} total={steps.length} className="mb-4" />
         <ol className="space-y-2.5">
           {steps.map((step) => (
             <StepRow key={step.n} step={step} primary={step === primaryStep} />

--- a/web/src/components/IntroDialog.tsx
+++ b/web/src/components/IntroDialog.tsx
@@ -3,6 +3,7 @@ import { INTRO } from "../guide";
 import { useStore } from "../store";
 import { Dialog } from "./Dialog";
 import { GuideEntry } from "./GuideDialog";
+import { Progress } from "./Progress";
 
 export function IntroDialog() {
   const [page, setPage] = useState(0);
@@ -16,11 +17,7 @@ export function IntroDialog() {
           <GuideEntry key={INTRO[page].id} section={INTRO[page]} lead />
         </div>
         <footer className="hairline flex items-center gap-2 pt-4">
-          <div aria-hidden className="flex flex-1 items-center gap-1.5">
-            {INTRO.map((entry, i) => (
-              <span key={entry.id} className={`h-1.5 w-4 rounded-full ${i === page ? "bg-accent" : "bg-ink-3"}`} />
-            ))}
-          </div>
+          <Progress value={page + 1} total={INTRO.length} className="flex-1" />
           {page > 0 && (
             <button className="btn" onClick={() => setPage(page - 1)}>
               Back

--- a/web/src/components/Progress.tsx
+++ b/web/src/components/Progress.tsx
@@ -1,0 +1,21 @@
+export function Progress({ value, total, className = "" }: { value: number; total: number; className?: string }) {
+  return (
+    <div
+      className={`flex items-center gap-3 ${className}`}
+      role="progressbar"
+      aria-valuenow={value}
+      aria-valuemin={0}
+      aria-valuemax={total}
+    >
+      <div aria-hidden className="h-1.5 flex-1 overflow-hidden rounded-full bg-accent/25">
+        <div
+          className="h-full rounded-full bg-accent transition-[width] duration-500"
+          style={{ width: `${(value / total) * 100}%` }}
+        />
+      </div>
+      <span className="label whitespace-nowrap">
+        {value} of {total}
+      </span>
+    </div>
+  );
+}


### PR DESCRIPTION
Follow-up to #111. The walkthrough's pager and the Getting Started checklist both drew their track in `ink-3`, which sits a shade off the panel in dark and turns into a near-transparent black in Glass, so all you saw was an orange pill moving with nothing to measure it against.

Both now share one progress component with a track at a quarter of the accent, and the walkthrough gained the same 'n of m' count the checklist has. Checked in dark, light and Glass at 900px and 375px.