### PR TITLE
Hold the walkthrough to one screen

### DIFF
--- a/web/src/components/Dialog.tsx
+++ b/web/src/components/Dialog.tsx
@@ -57,20 +57,24 @@ export function Dialog({
   title,
   onClose,
   size = "default",
+  fixed = false,
   children,
 }: {
   title: string;
   onClose: () => void;
   size?: "default" | "wide";
+  fixed?: boolean;
   children: ReactNode;
 }) {
   const titleId = useId();
   return (
     <Modal onClose={onClose} labelledBy={titleId}>
       <div
-        className={`panel rise-in w-full ${size === "wide" ? "sm:max-w-2xl" : "sm:max-w-lg"} max-h-[92vh] overflow-y-auto rounded-b-none sm:rounded-md`}
+        className={`panel rise-in w-full ${size === "wide" ? "sm:max-w-2xl" : "sm:max-w-lg"} rounded-b-none sm:rounded-md ${
+          fixed ? "flex h-[min(92vh,46rem)] flex-col overflow-hidden" : "max-h-[92vh] overflow-y-auto"
+        }`}
       >
-        <div className="flex items-center justify-between px-5 py-3 border-b border-line-0">
+        <div className="flex shrink-0 items-center justify-between px-5 py-3 border-b border-line-0">
           <h2 id={titleId} className="display text-sm font-semibold text-text-1">
             {title}
           </h2>
@@ -83,7 +87,7 @@ export function Dialog({
             ×
           </button>
         </div>
-        <div className="p-5">{children}</div>
+        <div className={`p-5 ${fixed ? "min-h-0 flex-1" : ""}`}>{children}</div>
       </div>
     </Modal>
   );

--- a/web/src/components/GuideDialog.tsx
+++ b/web/src/components/GuideDialog.tsx
@@ -5,20 +5,20 @@ import { Dialog } from "./Dialog";
 const REPO = "https://github.com/oliverbravery/PrintGuard";
 const MODEL = "https://github.com/oliverbravery/Edge-FDM-Fault-Detection";
 
-export function GuideEntry({ section, lead }: { section: GuideSection; lead?: boolean }) {
+export function GuideEntry({ section, lead, fill }: { section: GuideSection; lead?: boolean; fill?: boolean }) {
   const openDialog = useStore((s) => s.openDialog);
   const { action } = section;
   return (
-    <section className="reveal">
-      <div className="mb-1.5 flex items-center gap-2.5">
+    <section className={`reveal ${fill ? "flex h-full min-h-0 flex-col" : ""}`}>
+      <div className="mb-1.5 flex shrink-0 items-center gap-2.5">
         <span className={`led ${section.led}`} />
         <h3 className={lead ? "display text-base font-bold" : "display text-sm font-semibold tracking-[0.14em]"}>
           {section.title}
         </h3>
       </div>
-      <p className={`leading-relaxed text-text-1 ${lead ? "text-sm" : "text-[0.84rem]"}`}>{section.body}</p>
+      <p className={`shrink-0 leading-relaxed text-text-1 ${lead ? "text-sm" : "text-[0.84rem]"}`}>{section.body}</p>
       {section.shot && (
-        <figure className="shot">
+        <figure className={`shot ${fill ? "shot-fill" : ""}`}>
           <img className="shot-dark" src={`guide/${section.shot}-dark.jpg`} alt="" loading="lazy" />
           <img className="shot-light" src={`guide/${section.shot}-light.jpg`} alt="" loading="lazy" />
         </figure>

--- a/web/src/components/IntroDialog.tsx
+++ b/web/src/components/IntroDialog.tsx
@@ -11,22 +11,22 @@ export function IntroDialog() {
   const close = () => openDialog(null);
   const last = page === INTRO.length - 1;
   return (
-    <Dialog title="How PrintGuard works" onClose={close}>
-      <div className="space-y-5">
-        <div aria-live="polite" className="grid max-h-[52vh] overflow-y-auto">
+    <Dialog title="How PrintGuard works" onClose={close} fixed>
+      <div className="flex h-full flex-col gap-4">
+        <div aria-live="polite" className="grid min-h-0 flex-1">
           {INTRO.map((entry, i) => (
             <div
               key={entry.id}
-              className={`col-start-1 row-start-1 ${i === page ? "page-swap" : ""}`}
+              className={`col-start-1 row-start-1 min-h-0 ${i === page ? "page-swap" : ""}`}
               style={{ visibility: i === page ? undefined : "hidden" }}
               aria-hidden={i !== page}
               inert={i !== page}
             >
-              <GuideEntry section={entry} lead />
+              <GuideEntry section={entry} lead fill />
             </div>
           ))}
         </div>
-        <footer className="hairline flex items-center gap-2 pt-4">
+        <footer className="hairline flex shrink-0 items-center gap-2 pt-4">
           <Progress value={page + 1} total={INTRO.length} className="flex-1" />
           {page > 0 && (
             <button className="btn" onClick={() => setPage(page - 1)}>

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -720,6 +720,16 @@ video {
   margin-top: 0.75rem;
 }
 
+.shot-fill {
+  flex: 0 1 auto;
+  min-height: 0;
+}
+
+.shot-fill img {
+  max-height: 100%;
+  width: auto;
+}
+
 .shot img {
   display: block;
   width: 100%;


### PR DESCRIPTION
Reported in #122.

The walkthrough panel is a fixed height now, and each page's screenshot shrinks to the space the text leaves, so no page scrolls and no image needs scrolling to see whole. Checked across all five pages at desktop and 375px, with the panel reporting zero overflow on each.