### PR TITLE
v2.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ release notes.
 The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions follow
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.5.0] - 2026-09-01
+
 ## [2.4.0] - 2026-08-24
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "printguard"
-version = "2.4.0"
+version = "2.5.0"
 description = "Real-time 3D print failure detection"
 
 license = "GPL-2.0-only"

--- a/uv.lock
+++ b/uv.lock
@@ -1206,7 +1206,7 @@ wheels = [
 
 [[package]]
 name = "printguard"
-version = "2.4.0"
+version = "2.5.0"
 source = { editable = "." }
 dependencies = [
     { name = "ai-edge-litert" },


### PR DESCRIPTION
Release branch for v2.5.0. It opens with the version bump and an empty changelog section so
CI has something to check, and work lands on top of it rather than straight on `main`.
Merging this ships the release.

### In this release

| Change | PR |
|---|---|
| Pushover as an alert channel, in both hub and local mode | #129 |
