### PR TITLE
Date a release the day it merges into main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,4 +89,12 @@ jobs:
             echo "::error file=CHANGELOG.md::no '## [${version}]' section — describe the change in CHANGELOG.md; it becomes the release notes"
             exit 1
           fi
+          if [ "${{ github.base_ref }}" = "main" ]; then
+            today=$(TZ=Europe/London date +%F)
+            dated=$(grep -m1 "^## \[${version}\]" CHANGELOG.md | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' || true)
+            if [ "${dated}" != "${today}" ]; then
+              echo "::error file=CHANGELOG.md::'## [${version}]' is dated '${dated}' but today is ${today} in London, a release carries the date it merges"
+              exit 1
+            fi
+          fi
           echo "v${version} is unreleased and documented"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,14 @@ jobs:
             echo "::error file=CHANGELOG.md::no '## [${{ steps.read.outputs.version }}]' section, describe the change in CHANGELOG.md; it becomes the release notes"
             exit 1
           fi
+      - name: Refuse to release a changelog dated any day but the one it merged, London time
+        run: |
+          merged=$(TZ=Europe/London date -d "$(git log -1 --format=%cI)" +%F)
+          dated=$(grep -m1 "^## \[${{ steps.read.outputs.version }}\]" CHANGELOG.md | grep -oE '[0-9]{4}-[0-9]{2}-[0-9]{2}' || true)
+          if [ "${dated}" != "${merged}" ]; then
+            echo "::error file=CHANGELOG.md::'## [${{ steps.read.outputs.version }}]' is dated '${dated}' but it merged on ${merged} in London, correct the date and merge again"
+            exit 1
+          fi
 
   docker:
     name: image (${{ matrix.name }})

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
   sliced 3mf. The REST API and MCP server can list, tag and start files too.
   [docs/printers.md](docs/printers.md#sending-prints) has the details.
 
-## [2.4.1] - 2026-09-01
+## [2.4.1] - 2026-09-09
 
 ### Added
 
@@ -127,7 +127,7 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
   camera's full frame rate with nothing explaining why. A printer that starts reporting again
   is announced as recovered even if it comes back idle.
 
-## [2.3.12] - 2026-08-12
+## [2.3.12] - 2026-08-13
 
 ### Fixed
 
@@ -174,7 +174,7 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
   leaves the bundled streaming server running behind it, holding port 8554 against the next
   hub you start.
 
-## [2.3.8] - 2026-07-24
+## [2.3.8] - 2026-08-02
 
 ### Added
 
@@ -230,7 +230,7 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
   on that machine, failed with "address already in use" from an app that was no longer
   running. The streaming server now always stops with the hub, however the hub ends.
 
-## [2.3.7] - 2026-07-22
+## [2.3.7] - 2026-07-24
 
 ### Added
 
@@ -362,7 +362,7 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
   sensitive data. The token is still shown once and only its hash is stored — nothing about your
   existing tokens changes.
 
-## [2.3.0] - 2026-07-03
+## [2.3.0] - 2026-07-10
 
 ### Added
 
@@ -522,7 +522,7 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
   starts the page. Text, status colours and the light theme were tuned to meet **WCAG 2.2 AA**
   contrast, and all motion respects your system's reduced-motion setting.
 
-## [2.1.2] - 2026-06-20
+## [2.1.2] - 2026-06-22
 
 ### Fixed
 
@@ -559,7 +559,7 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
   the live view and alert images (rotation, crop, brightness/contrast/sharpness) instead of
   returning the raw frame.
 
-## [2.1.0] - 2026-06-16
+## [2.1.0] - 2026-06-19
 
 ### Added
 
@@ -630,7 +630,7 @@ The format is [Keep a Changelog](https://keepachangelog.com/en/1.1.0/); versions
 - `LICENSE.md` with the full GNU General Public License v2 text, matching the
   `GPL-2.0-only` declaration in `pyproject.toml`.
 
-## [2.0.0] - 2026-06-12
+## [2.0.0] - 2026-06-15
 
 A ground-up rewrite. One Python engine now runs everywhere — in your browser on Pyodide
 or on a server on CPython — with every runtime difference behind a single `Platform`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -151,7 +151,8 @@ a matching top section in [CHANGELOG.md](CHANGELOG.md) ([Keep a Changelog](https
 form), which is published **verbatim** as the GitHub release notes - write it for someone
 deciding whether to pull the new image, not about the implementation. Three required checks
 must pass: **tests**, the production **image** build, and **version** (bumped past the last
-release with a matching changelog section). Docker is the only supported distribution.
+release with a matching changelog section, dated the day it merges into `main` in London
+time). Docker is the only supported distribution.
 
 Link every issue a PR resolves with a closing keyword (`Fixes #123`). The issue lifecycle
 hangs off that link: the merge reopens the issue rather than closing it, marks it

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -206,7 +206,10 @@ Then add a matching section at the top of [CHANGELOG.md](CHANGELOG.md) in
 ```
 
 The section is published verbatim as the GitHub release notes, so describe the user-visible
-effect, not the implementation.
+effect, not the implementation. Its date is the day the release merges into `main`, in London
+time. The check on a pull request into `main` compares it with today, and the release itself
+refuses a section dated any other day than its merge commit, so a release that waits a day
+needs its date moved on before it merges.
 
 A pull request can only merge once three required checks pass:
 
@@ -214,7 +217,7 @@ A pull request can only merge once three required checks pass:
 |---|---|
 | **tests** | The engine simulation suite |
 | **image** | Every production image variant builds, so a change that breaks an image can never reach `main` |
-| **version** | The version is bumped past the last release and has a matching `CHANGELOG.md` section, so every merge ships as a unique, documented, immutable version. Re-publishing an existing tag is refused |
+| **version** | The version is bumped past the last release and has a matching `CHANGELOG.md` section dated the day it merges into `main`, London time, so every merge ships as a unique, documented, immutable version. Re-publishing an existing tag is refused |
 
 On merge, the [release workflow](.github/workflows/release.yml):
 


### PR DESCRIPTION
The changelog heading has to carry the day the release merges, in London time. CI checks it against today on a PR into main, and the release workflow refuses a heading dated any day but its merge commit, so a release PR that waits needs its date moved on first.

Eight past headings were dated when the release branch was cut rather than when it shipped, so they now carry the day GitHub published them.